### PR TITLE
improve task cards 

### DIFF
--- a/client/src/components/Today/Activity.tsx
+++ b/client/src/components/Today/Activity.tsx
@@ -1,4 +1,5 @@
 import useActivity from "@/components/Today/use-activity.ts";
+import { Checkbox } from "@/lib/theme/components/Checkbox.tsx";
 import type { ActivityWithIds } from "@type/server/activity.types.ts";
 import type { ID } from "@type/server/utility.types.ts";
 import S from "./Today.style.ts";
@@ -23,8 +24,31 @@ export default function Activity({ activity, indentation }: ActivityProps) {
 			$offset={offset}
 			onClick={openActivityModal}
 		>
+			{/* TODO: on mouseover, display a short humanized time string */}
 			<S.Activity $durationHours={durationHours}>
 				<S.ActivityName>{activity.name}</S.ActivityName>
+				{activity.is_task && (
+					// checkbox!
+					// TODO: extract putCompletion to a hook, we already use it in 2
+					// other places I think so it should be generalized
+					// TODO: should really prioritize reworking checkboxes so we can
+					// stop using this pattern
+					<S.CheckboxWrapper
+						style={{ zIndex: 4 }}
+						onClick={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							// handle putCompletion()
+						}}
+					>
+						<input
+							type="checkbox"
+							checked={activity.completed}
+							style={{ display: "none" }}
+						/>
+						<Checkbox checked={activity.completed} />
+					</S.CheckboxWrapper>
+				)}
 			</S.Activity>
 		</S.ActivityCard>
 	);

--- a/client/src/components/Today/Activity.tsx
+++ b/client/src/components/Today/Activity.tsx
@@ -1,7 +1,7 @@
 import useActivity from "@/components/Today/use-activity.ts";
 import type { ActivityWithIds } from "@type/server/activity.types.ts";
 import type { ID } from "@type/server/utility.types.ts";
-import * as S from "./Today.style.ts";
+import S from "./Today.style.ts";
 
 export type ActivityProps = {
 	activity: ActivityWithIds;

--- a/client/src/components/Today/HourMark.tsx
+++ b/client/src/components/Today/HourMark.tsx
@@ -1,5 +1,5 @@
 import { formatHour } from "@lib/datetime/format-date";
-import * as S from "./Today.style";
+import S from "./Today.style";
 
 export default function HourMark({ index }: { index: number }) {
 	const label = formatHour(index);

--- a/client/src/components/Today/Notes.tsx
+++ b/client/src/components/Today/Notes.tsx
@@ -2,7 +2,7 @@ import { isToday } from "@lib/datetime/compare";
 import useNotesQuery from "@lib/query/use-notes-query";
 import useTagsQuery from "@lib/query/use-tags-query";
 import { Note } from "./Note";
-import * as S from "./Today.style";
+import S from "./Today.style";
 
 export default function Notes() {
 	const { data } = useNotesQuery();

--- a/client/src/components/Today/Row.tsx
+++ b/client/src/components/Today/Row.tsx
@@ -2,7 +2,7 @@ import type { ActivityWithIds } from "@type/server/activity.types";
 import type { ID } from "@type/server/utility.types";
 import Activity from "./Activity";
 import HourMark from "./HourMark";
-import * as S from "./Today.style";
+import S from "./Today.style";
 
 type RowProps = {
 	index: number;

--- a/client/src/components/Today/Task.tsx
+++ b/client/src/components/Today/Task.tsx
@@ -6,7 +6,8 @@ import type { ActivityWithIds } from "@type/server/activity.types";
 import type { TagWithIds } from "@type/server/tag.types";
 import type { ById } from "@type/server/utility.types";
 import TagCard from "../TagCard/TagCard";
-import * as S from "./Today.style";
+import T from "./Tasks.style";
+import S from "./Today.style";
 
 type TaskProps = {
 	activity: ActivityWithIds;
@@ -22,7 +23,7 @@ export default function Task({ activity, tagsById }: TaskProps) {
 	}
 
 	return (
-		<S.Task>
+		<T.Task>
 			<S.CheckboxWrapper>
 				<S.Checkbox
 					type="checkbox"
@@ -32,17 +33,17 @@ export default function Task({ activity, tagsById }: TaskProps) {
 				/>
 				<Checkbox checked={activity.completed} />
 			</S.CheckboxWrapper>
-			<S.TaskName>{activity.name}</S.TaskName>
-			<S.Times>
+			<T.TaskName>{activity.name}</T.TaskName>
+			<T.Times>
 				{activityStart(activity).format("HH:mm")}
 				{" - "}
 				{activityEnd(activity).format("HH:mm")}
-			</S.Times>
-			<S.Tags>
+			</T.Times>
+			<T.Tags>
 				{tags.map((tag) => (
 					<TagCard key={tag.tag_id} tag={tag} />
 				))}
-			</S.Tags>
-		</S.Task>
+			</T.Tags>
+		</T.Task>
 	);
 }

--- a/client/src/components/Today/Task.tsx
+++ b/client/src/components/Today/Task.tsx
@@ -7,6 +7,7 @@ import { filterTagsById } from "@lib/filter-tags";
 import type { ActivityWithIds } from "@type/server/activity.types";
 import type { TagWithIds } from "@type/server/tag.types";
 import type { ById } from "@type/server/utility.types";
+import { useCallback, useRef } from "react";
 import TagCard from "../TagCard/TagCard";
 import T from "./Tasks.style";
 import S from "./Today.style";
@@ -18,6 +19,7 @@ type TaskProps = {
 
 export default function Task({ activity, tagsById }: TaskProps) {
 	const tags = filterTagsById(activity.tag_ids, tagsById); // TODO: pass this as a prop and, in Tasks, get it from a hook
+	const checkboxRef = useRef<HTMLLabelElement>(null);
 
 	const { mutate } = useTaskCompletionMutation();
 	function putCompletion() {
@@ -26,23 +28,23 @@ export default function Task({ activity, tagsById }: TaskProps) {
 
 	const { setModalState } = useModalState(modalIds.detailedActivity);
 
-	function openTaskModal(e: React.MouseEvent) {
-		setModalState(() => ({
-			isOpen: true,
-			itemId: activity.activity_id,
-			itemType: "activity"
-		}));
-		e.stopPropagation();
-	}
+	const maybeOpenTaskModal = useCallback(
+		(e: React.MouseEvent) => {
+			if (checkboxRef.current?.contains(e.target as Node)) return;
+
+			setModalState(() => ({
+				isOpen: true,
+				itemId: activity.activity_id,
+				itemType: "activity"
+			}));
+			e.stopPropagation();
+		},
+		[checkboxRef, activity]
+	);
 
 	return (
-		<T.Task
-			onClick={(e) => {
-				e.stopPropagation();
-				openTaskModal(e);
-			}}
-		>
-			<S.CheckboxWrapper>
+		<T.Task onClick={maybeOpenTaskModal}>
+			<S.CheckboxWrapper ref={checkboxRef}>
 				<S.Checkbox
 					type="checkbox"
 					style={{ display: "none" }}

--- a/client/src/components/Today/Task.tsx
+++ b/client/src/components/Today/Task.tsx
@@ -35,9 +35,8 @@ export default function Task({ activity, tagsById }: TaskProps) {
 			</S.CheckboxWrapper>
 			<T.TaskName>{activity.name}</T.TaskName>
 			<T.Times>
-				{activityStart(activity).format("HH:mm")}
-				{" - "}
-				{activityEnd(activity).format("HH:mm")}
+				<span>from {activityStart(activity).format("HH:mm")}</span>
+				<span>to {activityEnd(activity).format("HH:mm")}</span>
 			</T.Times>
 			<T.Tags>
 				{tags.map((tag) => (

--- a/client/src/components/Today/Task.tsx
+++ b/client/src/components/Today/Task.tsx
@@ -1,4 +1,6 @@
+import modalIds from "@/lib/modal-ids";
 import useTaskCompletionMutation from "@/lib/query/use-task-mutation";
+import { useModalState } from "@/lib/state/modal-state";
 import { Checkbox } from "@/lib/theme/components/Checkbox";
 import { activityEnd, activityStart } from "@lib/activity";
 import { filterTagsById } from "@lib/filter-tags";
@@ -22,8 +24,24 @@ export default function Task({ activity, tagsById }: TaskProps) {
 		mutate({ ...activity, completed: !activity.completed });
 	}
 
+	const { setModalState } = useModalState(modalIds.detailedActivity);
+
+	function openTaskModal(e: React.MouseEvent) {
+		setModalState(() => ({
+			isOpen: true,
+			itemId: activity.activity_id,
+			itemType: "activity"
+		}));
+		e.stopPropagation();
+	}
+
 	return (
-		<T.Task>
+		<T.Task
+			onClick={(e) => {
+				e.stopPropagation();
+				openTaskModal(e);
+			}}
+		>
 			<S.CheckboxWrapper>
 				<S.Checkbox
 					type="checkbox"
@@ -33,11 +51,11 @@ export default function Task({ activity, tagsById }: TaskProps) {
 				/>
 				<Checkbox checked={activity.completed} />
 			</S.CheckboxWrapper>
-			<T.TaskName>{activity.name}</T.TaskName>
 			<T.Times>
 				<span>from {activityStart(activity).format("HH:mm")}</span>
 				<span>to {activityEnd(activity).format("HH:mm")}</span>
 			</T.Times>
+			<T.TaskName>{activity.name}</T.TaskName>
 			<T.Tags>
 				{tags.map((tag) => (
 					<TagCard key={tag.tag_id} tag={tag} />

--- a/client/src/components/Today/Task.tsx
+++ b/client/src/components/Today/Task.tsx
@@ -1,13 +1,9 @@
-import modalIds from "@/lib/modal-ids";
-import useTaskCompletionMutation from "@/lib/query/use-task-mutation";
-import { useModalState } from "@/lib/state/modal-state";
+import useTask from "@/components/Today/use-task";
 import { Checkbox } from "@/lib/theme/components/Checkbox";
 import { activityEnd, activityStart } from "@lib/activity";
-import { filterTagsById } from "@lib/filter-tags";
 import type { ActivityWithIds } from "@type/server/activity.types";
 import type { TagWithIds } from "@type/server/tag.types";
 import type { ById } from "@type/server/utility.types";
-import { useCallback, useRef } from "react";
 import TagCard from "../TagCard/TagCard";
 import T from "./Tasks.style";
 import S from "./Today.style";
@@ -18,29 +14,10 @@ type TaskProps = {
 };
 
 export default function Task({ activity, tagsById }: TaskProps) {
-	const tags = filterTagsById(activity.tag_ids, tagsById); // TODO: pass this as a prop and, in Tasks, get it from a hook
-	const checkboxRef = useRef<HTMLLabelElement>(null);
-
-	const { mutate } = useTaskCompletionMutation();
-	function putCompletion() {
-		mutate({ ...activity, completed: !activity.completed });
-	}
-
-	const { setModalState } = useModalState(modalIds.detailedActivity);
-
-	const maybeOpenTaskModal = useCallback(
-		(e: React.MouseEvent) => {
-			if (checkboxRef.current?.contains(e.target as Node)) return;
-
-			setModalState(() => ({
-				isOpen: true,
-				itemId: activity.activity_id,
-				itemType: "activity"
-			}));
-			e.stopPropagation();
-		},
-		[checkboxRef, activity]
-	);
+	const { checkboxRef, maybeOpenTaskModal, putCompletion, tags } = useTask({
+		activity,
+		tagsById
+	});
 
 	return (
 		<T.Task onClick={maybeOpenTaskModal}>

--- a/client/src/components/Today/Tasks.style.ts
+++ b/client/src/components/Today/Tasks.style.ts
@@ -37,6 +37,9 @@ const Tags = styled.div`
 
 const Times = styled.div`
 	width: max-content;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
 `;
 
 const Tasks = styled.ul`

--- a/client/src/components/Today/Tasks.style.ts
+++ b/client/src/components/Today/Tasks.style.ts
@@ -1,16 +1,20 @@
 import { Tag } from "@/components/TagCard/TagCard.style";
 import styled from "styled-components";
 
-const TasksWrapper = styled.section`
-	border: 2px solid #ccc;
-`;
+const TasksWrapper = styled.section``;
 
 const TaskName = styled.div`
 	display: flex;
-	width: 200px;
+	max-width: 200px;
 	white-space: normal;
 	overflow: hidden;
 	text-overflow: ellipsis;
+
+	color: #333;
+	background-color: #eee;
+	padding: 0.4rem 0.7rem;
+	border-radius: 4px;
+	box-shadow: 0 0.1rem 0.2rem 0 #bbb;
 `;
 
 const Tags = styled.div`
@@ -40,28 +44,43 @@ const Times = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;
+	font-size: 0.8rem;
+
+	color: #555;
 `;
 
 const Tasks = styled.ul`
 	display: flex;
 	flex-direction: column;
-	gap: 0.3rem;
+	gap: 0.6rem;
 	overflow-x: auto;
+	margin: 0 0.5rem;
+	max-width: 720px;
+	height: 100%; // TODO: only apply this when in list/column view?
 `;
 
 const Task = styled.li`
+	user-select: none;
 	list-style: none;
 	box-sizing: border-box;
 	font-size: 0.9rem;
 	display: grid;
-	grid-template-columns: max-content max-content max-content auto;
-	gap: 0.5rem;
-	border-radius: 2px;
-	background-color: #ddd;
+
+	grid-template-columns: max-content min-content max-content auto;
+
+	gap: 1rem;
+
+	@media (min-width: 1920px) {
+		gap: 2rem;
+	}
+
+	border-radius: 3px;
+	background-color: #ddd; // TODO: apply some style for completed tasks
 	width: 100%;
 	padding: 0.5rem 1rem;
 	align-items: center;
 	max-height: 90px;
+	box-shadow: 0.55rem 0.55rem 0.2rem -0.3rem #ccc;
 
 	max-width: 720px; // TODO: this is temporary, but we do want to limit size
 `;

--- a/client/src/components/Today/Tasks.style.ts
+++ b/client/src/components/Today/Tasks.style.ts
@@ -1,0 +1,73 @@
+import { Tag } from "@/components/TagCard/TagCard.style";
+import styled from "styled-components";
+
+const TasksWrapper = styled.section`
+	border: 2px solid #ccc;
+`;
+
+const TaskName = styled.div`
+	display: flex;
+	width: 200px;
+	white-space: normal;
+	overflow: hidden;
+	text-overflow: ellipsis;
+`;
+
+const Tags = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	flex-wrap: wrap;
+	gap: 0.4rem;
+	max-width: 250px;
+	justify-self: flex-end;
+	flex-wrap: wrap;
+	overflow-y: hidden;
+	max-height: 70px;
+
+	${Tag} {
+		display: flex;
+		max-height: 30px;
+		flex: 1;
+		overflow-y: visible;
+		white-space: nowrap;
+		max-width: 100%;
+		justify-content: center;
+	}
+`;
+
+const Times = styled.div`
+	width: max-content;
+`;
+
+const Tasks = styled.ul`
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	overflow-x: auto;
+`;
+
+const Task = styled.li`
+	list-style: none;
+	box-sizing: border-box;
+	font-size: 0.9rem;
+	display: grid;
+	grid-template-columns: max-content max-content max-content auto;
+	gap: 0.5rem;
+	border-radius: 2px;
+	background-color: #ddd;
+	width: 100%;
+	padding: 0.5rem 1rem;
+	align-items: center;
+	max-height: 90px;
+
+	max-width: 720px; // TODO: this is temporary, but we do want to limit size
+`;
+
+export default {
+	TasksWrapper,
+	TaskName,
+	Tags,
+	Times,
+	Tasks,
+	Task,
+};

--- a/client/src/components/Today/Tasks.style.ts
+++ b/client/src/components/Today/Tasks.style.ts
@@ -77,6 +77,7 @@ const Task = styled.li`
 	border-radius: 3px;
 	background-color: #ddd; // TODO: apply some style for completed tasks
 	width: 100%;
+	min-width: max-content;
 	padding: 0.5rem 1rem;
 	align-items: center;
 	max-height: 90px;

--- a/client/src/components/Today/Tasks.tsx
+++ b/client/src/components/Today/Tasks.tsx
@@ -1,7 +1,8 @@
 import useTagsQuery from "@lib/query/use-tags-query";
 import type { ActivityWithIds } from "@type/server/activity.types";
 import Task from "./Task";
-import * as S from "./Today.style";
+import T from "./Tasks.style";
+import S from "./Today.style";
 
 type TasksProps = {
 	activities: ActivityWithIds[];
@@ -11,13 +12,13 @@ export default function Tasks({ activities }: TasksProps) {
 	const { data: tags } = useTagsQuery();
 
 	return (
-		<S.TasksWrapper>
+		<T.TasksWrapper>
 			<S.BlockTitle>Tasks</S.BlockTitle>
-			<S.Tasks>
+			<T.Tasks>
 				{activities.map((a) => (
 					<Task key={a.activity_id} activity={a} tagsById={tags?.tagsById} />
 				))}
-			</S.Tasks>
-		</S.TasksWrapper>
+			</T.Tasks>
+		</T.TasksWrapper>
 	);
 }

--- a/client/src/components/Today/Today.style.ts
+++ b/client/src/components/Today/Today.style.ts
@@ -7,12 +7,9 @@ const TimelineWrapper = styled.section`
 	display: flex;
 	flex-direction: column;
 	padding: 1rem 3rem;
-	border: 2px solid #ccc;
 `;
 
-const NotesWrapper = styled.section`
-	border: 2px solid #ccc;
-`;
+const NotesWrapper = styled.section``;
 
 const BlockTitle = styled.h2`
 	width: max-content;
@@ -42,9 +39,30 @@ const HourMark = styled.span`
 	height: 1.5rem;
 	top: -0.75rem; // TODO: this has to be such that the text is centered right in between two rows
 	left: -1rem;
-	background-color: #ccc;
+	background-color: #eee;
+	outline: 1px solid #333;
+	font-size: 0.75rem;
+	color: #222;
 	width: max-content;
+	border-radius: 3px;
 	padding: 0 0.5rem;
+	user-select: none;
+`;
+
+const CheckboxWrapper = styled.label`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 27px;
+	height: 27px;
+
+	.on {
+		fill: forestgreen;
+	}
+
+	.off {
+		fill: #aaa;
+	}
 `;
 
 const cardWidth = 175;
@@ -58,6 +76,14 @@ const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	display: flex;
 	width: 100%;
 	height: max-content;
+
+	${CheckboxWrapper} {
+		position: absolute;
+		top: 0.2rem;
+		right: 0.2rem;
+		border-radius: 50%;
+		background-color: #eee;
+	}
 `;
 
 const Activity = styled.div<{ $durationHours: number }>`
@@ -85,23 +111,12 @@ const Activity = styled.div<{ $durationHours: number }>`
 
 const ActivityName = styled.span`
 	max-width: max-content;
-	padding: 0.2rem 1rem;
-`;
-
-const CheckboxWrapper = styled.label`
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 27px;
-	height: 27px;
-
-	.on {
-		fill: forestgreen;
-	}
-
-	.off {
-		fill: #aaa;
-	}
+	padding: 0.2rem;
+	z-index: 4;
+	// ellipsis on overflow
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 `;
 
 const Checkbox = styled.input`
@@ -113,8 +128,8 @@ const Checkbox = styled.input`
 const Columns = styled.div`
 	display: grid;
 
-	@media (min-width: 1920px) {
-		grid-template-columns: repeat(3, 1fr);
+	@media (min-width: 1280px) {
+		grid-template-columns: 1.5fr 1fr 1fr;
 	}
 
 	grid-template-columns: 1fr;

--- a/client/src/components/Today/Today.style.ts
+++ b/client/src/components/Today/Today.style.ts
@@ -129,7 +129,7 @@ const Columns = styled.div`
 	display: grid;
 
 	@media (min-width: 1280px) {
-		grid-template-columns: 1.5fr 1fr 1fr;
+		grid-template-columns: 1fr max-content auto; // TODO: this is still temporary because the whole layout is temporary
 	}
 
 	grid-template-columns: 1fr;

--- a/client/src/components/Today/Today.style.ts
+++ b/client/src/components/Today/Today.style.ts
@@ -1,36 +1,32 @@
-import { Tag } from "@/components/TagCard/TagCard.style";
 import styled from "styled-components";
+import T from "./Tasks.style";
 
-export const Wrapper = styled.div``;
+const Wrapper = styled.div``;
 
-export const TimelineWrapper = styled.section`
+const TimelineWrapper = styled.section`
 	display: flex;
 	flex-direction: column;
 	padding: 1rem 3rem;
 	border: 2px solid #ccc;
 `;
 
-export const TasksWrapper = styled.section`
+const NotesWrapper = styled.section`
 	border: 2px solid #ccc;
 `;
 
-export const NotesWrapper = styled.section`
-	border: 2px solid #ccc;
-`;
-
-export const BlockTitle = styled.h2`
+const BlockTitle = styled.h2`
 	width: max-content;
 	padding: 0.5rem 1rem;
 `;
 
-export const Rows = styled.ul`
+const Rows = styled.ul`
 	display: flex;
 	flex-direction: column;
 `;
 
 const rowHeight = 40;
 
-export const Row = styled.li`
+const Row = styled.li`
 	position: relative;
 	display: flex;
 	border-top: 2px solid #ddd;
@@ -38,7 +34,7 @@ export const Row = styled.li`
 	width: 100%;
 `;
 
-export const HourMark = styled.span`
+const HourMark = styled.span`
 	display: flex;
 	align-self: center;
 	position: absolute;
@@ -54,7 +50,7 @@ export const HourMark = styled.span`
 const cardWidth = 175;
 const cardGap = 5;
 
-export const ActivityCard = styled.div<{ $level: number; $offset: number }>`
+const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	position: absolute;
 	top: calc(${(p) => p.$offset * 100}%);
 	left: calc(3rem + ${(p) => p.$level * (cardGap + cardWidth)}px);
@@ -64,7 +60,7 @@ export const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	height: max-content;
 `;
 
-export const Activity = styled.div<{ $durationHours: number }>`
+const Activity = styled.div<{ $durationHours: number }>`
 	display: flex;
 	position: absolute;
 	z-index: 2;
@@ -87,36 +83,12 @@ export const Activity = styled.div<{ $durationHours: number }>`
 	}
 `;
 
-export const ActivityName = styled.span`
+const ActivityName = styled.span`
 	max-width: max-content;
 	padding: 0.2rem 1rem;
 `;
 
-export const Tasks = styled.ul`
-	display: flex;
-	flex-direction: column;
-	gap: 0.3rem;
-	overflow-x: auto;
-`;
-
-export const Task = styled.li`
-	list-style: none;
-	box-sizing: border-box;
-	font-size: 0.9rem;
-	display: grid;
-	grid-template-columns: max-content max-content max-content auto;
-	gap: 0.5rem;
-	border-radius: 2px;
-	background-color: #ddd;
-	width: 100%;
-	padding: 0.5rem 1rem;
-	align-items: center;
-	max-height: 90px;
-
-	max-width: 720px; // TODO: this is temporary, but we do want to limit size
-`;
-
-export const CheckboxWrapper = styled.label`
+const CheckboxWrapper = styled.label`
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -132,13 +104,13 @@ export const CheckboxWrapper = styled.label`
 	}
 `;
 
-export const Checkbox = styled.input`
+const Checkbox = styled.input`
 	display: block;
 	margin-right: 0.5rem;
 	width: max-content;
 `;
 
-export const Columns = styled.div`
+const Columns = styled.div`
 	display: grid;
 
 	@media (min-width: 1920px) {
@@ -150,40 +122,7 @@ export const Columns = styled.div`
 	gap: 0.5rem;
 `;
 
-export const TaskName = styled.div`
-	display: flex;
-	width: 200px;
-	white-space: normal;
-	overflow: hidden;
-	text-overflow: ellipsis;
-`;
-
-export const Times = styled.div`
-	width: max-content;
-`;
-
-export const Tags = styled.div`
-	display: flex;
-	justify-content: flex-end;
-	flex-wrap: wrap;
-	gap: 0.4rem;
-	max-width: 250px;
-	justify-self: flex-end;
-	flex-wrap: wrap;
-	overflow-y: hidden;
-	max-height: 70px;
-
-	${Tag} {
-		display: flex;
-		max-height: 30px;
-		flex: 1;
-		overflow-y: visible;
-		white-space: nowrap;
-		max-width: 100%;
-	}
-`;
-
-export const Note = styled.li`
+const Note = styled.li`
 	list-style: none;
 	display: grid;
 	align-items: center;
@@ -192,7 +131,7 @@ export const Note = styled.li`
 		"content content"
 		"content content";
 
-	${Tags} {
+	${T.Tags} {
 		grid-area: tags;
 	}
 
@@ -200,13 +139,32 @@ export const Note = styled.li`
 	padding: 0.5rem 0rem;
 `;
 
-export const NoteTitle = styled.h3`
+const NoteTitle = styled.h3`
 	width: max-content;
 	padding: 0.3rem 0.8rem;
 	grid-area: title;
 `;
 
-export const NoteContent = styled.div`
+const NoteContent = styled.div`
 	padding: 0.5rem 1rem;
 	grid-area: content;
 `;
+
+export default {
+	Wrapper,
+	TimelineWrapper,
+	NotesWrapper,
+	BlockTitle,
+	Rows,
+	Row,
+	HourMark,
+	ActivityCard,
+	Activity,
+	ActivityName,
+	CheckboxWrapper,
+	Checkbox,
+	Columns,
+	Note,
+	NoteTitle,
+	NoteContent,
+};

--- a/client/src/components/Today/Today.style.ts
+++ b/client/src/components/Today/Today.style.ts
@@ -1,3 +1,4 @@
+import { Tag } from "@/components/TagCard/TagCard.style";
 import styled from "styled-components";
 
 export const Wrapper = styled.div``;
@@ -103,13 +104,14 @@ export const Task = styled.li`
 	box-sizing: border-box;
 	font-size: 0.9rem;
 	display: grid;
-	grid-template-columns: max-content 200px max-content auto;
+	grid-template-columns: max-content max-content max-content auto;
 	gap: 0.5rem;
 	border-radius: 2px;
 	background-color: #ddd;
 	width: 100%;
 	padding: 0.5rem 1rem;
 	align-items: center;
+	max-height: 90px;
 
 	max-width: 720px; // TODO: this is temporary, but we do want to limit size
 `;
@@ -150,7 +152,10 @@ export const Columns = styled.div`
 
 export const TaskName = styled.div`
 	display: flex;
-	width: 300px;
+	width: 200px;
+	white-space: normal;
+	overflow: hidden;
+	text-overflow: ellipsis;
 `;
 
 export const Times = styled.div`
@@ -160,8 +165,22 @@ export const Times = styled.div`
 export const Tags = styled.div`
 	display: flex;
 	justify-content: flex-end;
-	flex-wrap: nowrap;
+	flex-wrap: wrap;
 	gap: 0.4rem;
+	max-width: 250px;
+	justify-self: flex-end;
+	flex-wrap: wrap;
+	overflow-y: hidden;
+	max-height: 70px;
+
+	${Tag} {
+		display: flex;
+		max-height: 30px;
+		flex: 1;
+		overflow-y: visible;
+		white-space: nowrap;
+		max-width: 100%;
+	}
 `;
 
 export const Note = styled.li`

--- a/client/src/components/Today/Today.style.ts
+++ b/client/src/components/Today/Today.style.ts
@@ -110,6 +110,8 @@ export const Task = styled.li`
 	width: 100%;
 	padding: 0.5rem 1rem;
 	align-items: center;
+
+	max-width: 720px; // TODO: this is temporary, but we do want to limit size
 `;
 
 export const CheckboxWrapper = styled.label`
@@ -118,6 +120,14 @@ export const CheckboxWrapper = styled.label`
 	justify-content: center;
 	width: 27px;
 	height: 27px;
+
+	.on {
+		fill: forestgreen;
+	}
+
+	.off {
+		fill: #aaa;
+	}
 `;
 
 export const Checkbox = styled.input`

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -3,7 +3,7 @@ import { activityStartHour } from "@lib/activity";
 import Notes from "./Notes";
 import Row from "./Row";
 import Tasks from "./Tasks";
-import * as S from "./Today.style";
+import S from "./Today.style";
 import useToday from "./use-today";
 
 export default function Today() {

--- a/client/src/components/Today/use-task.ts
+++ b/client/src/components/Today/use-task.ts
@@ -1,0 +1,47 @@
+import { filterTagsById } from "@/lib/filter-tags";
+import modalIds from "@/lib/modal-ids";
+import useTaskCompletionMutation from "@/lib/query/use-task-mutation";
+import { useModalState } from "@/lib/state/modal-state";
+import type { ActivityWithIds } from "@/types/server/activity.types";
+import type { TagWithIds } from "@/types/server/tag.types";
+import type { ID } from "@/types/server/utility.types";
+import { useCallback, useRef } from "react";
+
+export default function useTask({
+	activity,
+	tagsById,
+}: {
+	activity: ActivityWithIds;
+	tagsById?: Record<ID, TagWithIds>;
+}) {
+	const tags = filterTagsById(activity.tag_ids, tagsById); // TODO: pass this as a prop and, in Tasks, get it from a hook
+	const checkboxRef = useRef<HTMLLabelElement>(null);
+
+	const { mutate } = useTaskCompletionMutation();
+	function putCompletion() {
+		mutate({ ...activity, completed: !activity.completed });
+	}
+
+	const { setModalState } = useModalState(modalIds.detailedActivity);
+
+	const maybeOpenTaskModal = useCallback(
+		(e: React.MouseEvent) => {
+			if (checkboxRef.current?.contains(e.target as Node)) return;
+
+			setModalState(() => ({
+				isOpen: true,
+				itemId: activity.activity_id,
+				itemType: "activity",
+			}));
+			e.stopPropagation();
+		},
+		[checkboxRef, activity],
+	);
+
+	return {
+		checkboxRef,
+		maybeOpenTaskModal,
+		putCompletion,
+		tags,
+	} as const;
+}


### PR DESCRIPTION
This is part of #47.

## UI/UX
I am thinking we streamline the view a little bit by going for two display options:
- timeline view. Here, we put activities and tasks in the timeline, and have Notes and potential other features in their own blocks. Even notes could maybe go in the timeline.
- list view. Here, we put everything in chronological order in a list.

Either way, clicking tasks in a list probably should just open an ActivityCard the same way clicking on an activity on the timeline does.