### PR TITLE
tweak timeline task styles

### DIFF
--- a/client/src/components/Today/Activity.tsx
+++ b/client/src/components/Today/Activity.tsx
@@ -1,15 +1,11 @@
 import { useDetailedActivityModal } from "@/components/Today/hooks/useDetailedActivityModal.ts";
 import { activityDuration, activityStart, activityStartHour } from "@/lib/activity.ts";
-import usePutTaskCompletion from "@/lib/hooks/usePutTaskCompletion.ts";
-import { Checkbox } from "@/lib/theme/components/Checkbox.tsx";
 import type { ActivityWithIds } from "@type/server/activity.types.ts";
 import T from "./style/Activity.style.ts";
-import S from "./style/Today.style.ts";
 
 function useActivity(activity: ActivityWithIds) {
 	const offset = activityStart(activity).minute() / 60; // TODO: BUG: this takes the start on the first day, needs the start on the displayed day
 	const { openDetailedActivityModal } = useDetailedActivityModal(activity);
-	const putCompletion = usePutTaskCompletion(activity);
 
 	/** This is the _displayed_ duration on the Today timeline. A multiday
 	 * activity still "ends" at midnight on this view. TODO: maybe change this
@@ -24,8 +20,7 @@ function useActivity(activity: ActivityWithIds) {
 	return {
 		durationHours,
 		offset,
-		openDetailedActivityModal,
-		putCompletion
+		openDetailedActivityModal
 	} as const;
 }
 
@@ -35,8 +30,7 @@ export type ActivityProps = {
 };
 
 export default function Activity({ activity, level }: ActivityProps) {
-	const { offset, openDetailedActivityModal, durationHours, putCompletion } =
-		useActivity(activity);
+	const { offset, openDetailedActivityModal, durationHours } = useActivity(activity);
 
 	return (
 		<T.ActivityCard
@@ -49,27 +43,8 @@ export default function Activity({ activity, level }: ActivityProps) {
 			}}
 		>
 			{/* TODO: on mouseover, display a short humanized time string */}
-			<T.Activity $durationHours={durationHours}>
+			<T.Activity $isTask={activity.is_task} $durationHours={durationHours}>
 				<T.ActivityName>{activity.name}</T.ActivityName>
-				{activity.is_task && (
-					// TODO: should really prioritize reworking checkboxes so we can
-					// stop using this pattern
-					<S.CheckboxWrapper
-						onClick={(e) => {
-							e.preventDefault();
-							e.stopPropagation();
-							putCompletion();
-						}}
-					>
-						<S.Checkbox
-							type="checkbox"
-							checked={activity.completed}
-							style={{ display: "none" }}
-							onChange={() => undefined} // TODO: this is just to prevent a warning
-						/>
-						<Checkbox checked={activity.completed} />
-					</S.CheckboxWrapper>
-				)}
 			</T.Activity>
 		</T.ActivityCard>
 	);

--- a/client/src/components/Today/Activity.tsx
+++ b/client/src/components/Today/Activity.tsx
@@ -43,7 +43,11 @@ export default function Activity({ activity, level }: ActivityProps) {
 			}}
 		>
 			{/* TODO: on mouseover, display a short humanized time string */}
-			<T.Activity $isTask={activity.is_task} $durationHours={durationHours}>
+			<T.Activity
+				$isTask={activity.is_task}
+				$durationHours={durationHours}
+				$completed={activity.completed}
+			>
 				<T.ActivityName>{activity.name}</T.ActivityName>
 			</T.Activity>
 		</T.ActivityCard>

--- a/client/src/components/Today/style/Activity.style.ts
+++ b/client/src/components/Today/style/Activity.style.ts
@@ -23,14 +23,14 @@ const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	}
 `;
 
-const Activity = styled.div<{ $durationHours: number }>`
+const Activity = styled.div<{ $durationHours: number; $isTask?: boolean }>`
 	display: flex;
 	position: absolute;
 	z-index: 2;
 	height: ${(p) => rowHeight * p.$durationHours}px;
 
 	padding: 0.5rem 1rem;
-	background-color: limegreen;
+	background-color: ${(p) => (p.$isTask ? "dodgerblue" : "limegreen")};
 	align-items: ${(p) => (p.$durationHours > 2 ? "flex-start" : "center")};
 
 	outline: 2px solid #eee;
@@ -41,7 +41,7 @@ const Activity = styled.div<{ $durationHours: number }>`
 
 	&:hover {
 		z-index: 3;
-		background-color: green;
+		background-color: ${(p) => (p.$isTask ? "royalblue" : "forestgreen")};
 		color: azure;
 	}
 `;

--- a/client/src/components/Today/style/Activity.style.ts
+++ b/client/src/components/Today/style/Activity.style.ts
@@ -1,5 +1,5 @@
 import { rowHeight } from "@/components/Today/style/TimelineRow.style";
-import { styled } from "styled-components";
+import { css, styled } from "styled-components";
 import S from "./Today.style";
 
 const cardWidth = 175;
@@ -7,6 +7,8 @@ const cardGap = 5;
 
 const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	position: absolute;
+	cursor: pointer;
+	user-select: none;
 	top: calc(${(p) => p.$offset * 100}%);
 	left: calc(3rem + ${(p) => p.$level * (cardGap + cardWidth)}px);
 	font-size: 0.86rem;
@@ -23,7 +25,11 @@ const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	}
 `;
 
-const Activity = styled.div<{ $durationHours: number; $isTask?: boolean }>`
+const Activity = styled.div<{
+	$durationHours: number;
+	$isTask?: boolean;
+	$completed?: boolean;
+}>`
 	display: flex;
 	position: absolute;
 	z-index: 2;
@@ -38,6 +44,16 @@ const Activity = styled.div<{ $durationHours: number; $isTask?: boolean }>`
 	border-radius: 3px;
 
 	transition: all 35ms ease-in;
+
+	${(p) =>
+		p.$completed &&
+		css`
+			opacity: 0.4;
+
+			&:hover {
+				opacity: 0.8;
+			}
+		`}
 
 	&:hover {
 		z-index: 3;

--- a/client/src/components/Today/style/Tasks.style.ts
+++ b/client/src/components/Today/style/Tasks.style.ts
@@ -39,6 +39,7 @@ const Tasks = styled.ul`
 const Task = styled.li`
 	user-select: none;
 	list-style: none;
+	cursor: pointer;
 	box-sizing: border-box;
 	font-size: 0.9rem;
 	display: grid;


### PR DESCRIPTION
Part of #34. 

Distinguishes tasks from regular activities by color (this probably needs to be revisited once we allow users to give activities colors).

Also removes the completion checkboxes from tasks on the timeline, because it causes visual clutter. Figure out something else for that. Especially for the case where a task is short-lived -- how do we provide a good experience when there is no room for a checkbox on the card itself? Click to open the card, then toggle the completion box? Just make users use the Tasks section?