### PR TITLE
`Today` styling pass

### DIFF
--- a/client/src/components/ActivityList/ActivityList.style.ts
+++ b/client/src/components/ActivityList/ActivityList.style.ts
@@ -70,7 +70,7 @@ export const Tag = styled.div`
 	padding: 0.2rem 0.6rem;
 	background-color: gold;
 	color: black;
-	font-size: 0.9rem;
+	font-size: ${(p) => p.theme.font.size["0.9"]};
 	width: max-content;
 	border-radius: 3px;
 `;
@@ -93,9 +93,10 @@ export const Checkbox = styled.input`
 	transition: all 25ms ease-out;
 
 	&:checked {
-		accent-color: forestgreen;
-		background-color: forestgreen;
-		border-color: forestgreen;
+		--color: ${(p) => p.theme.colors.green.main};
+		accent-color: var(--color);
+		background-color: var(--color);
+		border-color: var(--color);
 	}
 
 	&:hover {

--- a/client/src/components/ActivityList/ActivityList.style.ts
+++ b/client/src/components/ActivityList/ActivityList.style.ts
@@ -1,6 +1,7 @@
+import { getFontSize } from "@/lib/theme/font";
 import styled from "styled-components";
 
-export const Wrapper = styled.div`
+const Wrapper = styled.div`
 	margin: 1.2rem auto;
 
 	padding: 1.2rem 2rem;
@@ -9,13 +10,13 @@ export const Wrapper = styled.div`
 	border: 2px solid #aaa;
 `;
 
-export const List = styled.ul`
+const List = styled.ul`
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
 `;
 
-export const Item = styled.li`
+const Item = styled.li`
 	position: relative;
 	padding: 0.8rem 1.2rem;
 	box-shadow: 0 0 0.3rem 0 #ccc;
@@ -25,7 +26,7 @@ export const Item = styled.li`
 	min-width: 400px; // TODO: make this responsive
 `;
 
-export const Name = styled.h2`
+const Name = styled.h2`
 	font-size: ${(p) => getFontSize(p, 1.35)};
 	margin-bottom: 0.2rem;
 	border-bottom: 2px solid darkorchid;
@@ -37,20 +38,20 @@ export const Name = styled.h2`
 	margin-bottom: 0;
 `;
 
-export const Dates = styled.div`
+const Dates = styled.div`
 	font-size: ${(p) => getFontSize(p, 0.8)};
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;
 `;
 
-export const Title = styled.div`
+const Title = styled.div`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 `;
 
-export const Description = styled.section`
+const Description = styled.section`
 	box-shadow:
 		0.3rem 0.3rem 0 -0.1rem #ccc,
 		0 0 0.5rem 0 #ccc;
@@ -63,9 +64,9 @@ export const Description = styled.section`
 	border-radius: 3px;
 `;
 
-export const Date = styled.span``;
+const Date = styled.span``;
 
-export const Tag = styled.div`
+const Tag = styled.div`
 	margin-top: 0.4rem;
 	padding: 0.2rem 0.6rem;
 	background-color: gold;
@@ -77,7 +78,7 @@ export const Tag = styled.div`
 
 const checkboxSize = `25px`;
 
-export const Checkbox = styled.input`
+const Checkbox = styled.input`
 	position: absolute;
 	top: 50%;
 	right: -10px;
@@ -105,9 +106,23 @@ export const Checkbox = styled.input`
 	}
 `;
 
-export const Tags = styled.div`
+const Tags = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.3rem;
 	justify-content: flex-end;
 `;
+
+export default {
+	Wrapper,
+	List,
+	Item,
+	Name,
+	Dates,
+	Title,
+	Description,
+	Date,
+	Tag,
+	Checkbox,
+	Tags
+};

--- a/client/src/components/ActivityList/ActivityList.style.ts
+++ b/client/src/components/ActivityList/ActivityList.style.ts
@@ -26,7 +26,7 @@ export const Item = styled.li`
 `;
 
 export const Name = styled.h2`
-	font-size: 1.35rem;
+	font-size: ${(p) => getFontSize(p, 1.35)};
 	margin-bottom: 0.2rem;
 	border-bottom: 2px solid darkorchid;
 	width: max-content;
@@ -38,7 +38,7 @@ export const Name = styled.h2`
 `;
 
 export const Dates = styled.div`
-	font-size: 0.8rem;
+	font-size: ${(p) => getFontSize(p, 0.8)};
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;

--- a/client/src/components/ActivityList/ActivityList.tsx
+++ b/client/src/components/ActivityList/ActivityList.tsx
@@ -1,7 +1,7 @@
 import { filterTagsById } from "@lib/filter-tags";
 import type { ActivityWithIds } from "@type/server/activity.types";
 import type { TagWithIds } from "@type/server/tag.types";
-import * as S from "./ActivityList.style";
+import S from "./ActivityList.style";
 import { getFormattedDateField } from "./get-date-field";
 import useActivityList from "./useActivityList";
 

--- a/client/src/components/Calendar/Calendar.style.ts
+++ b/client/src/components/Calendar/Calendar.style.ts
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import type { CSSProperties } from "styled-components";
 import styled, { css } from "styled-components";
 
@@ -15,7 +16,7 @@ const Calendar = styled.div`
 	height: max-content;
 	margin-left: 1rem;
 	margin-top: 1rem;
-	--font-size: 0.8rem;
+	--font-size: ${(p) => getFontSize(p, 0.8)};
 	font-size: var(--font-size);
 	line-height: var(--font-size);
 	font-family: "Roboto";
@@ -35,7 +36,7 @@ const TitleWrapper = styled.div`
 `;
 
 const Title = styled.h2`
-	font-size: 1.2rem;
+	font-size: ${(p) => getFontSize(p, 1.2)};
 	color: ${highlightColor};
 	margin-bottom: calc(4 * ${gap});
 `;
@@ -60,7 +61,7 @@ const Days = styled.div`
 	background-color: #eee;
 	border-bottom: 2px solid ${highlightColor};
 	font-weight: 500;
-	font-size: 0.8rem;
+	font-size: ${(p) => getFontSize(p, 0.8)};
 `;
 
 type StyledCellProps = {

--- a/client/src/components/NewActivity/DateTimePicker.style.ts
+++ b/client/src/components/NewActivity/DateTimePicker.style.ts
@@ -2,7 +2,7 @@ import { inputStyle } from "@lib/theme/snippets/input";
 import styled, { css } from "styled-components";
 
 // TODO: rename this
-export const Form = styled.section`
+const Form = styled.section`
 	display: grid;
 	width: 100%;
 	gap: 0.1rem;
@@ -18,12 +18,12 @@ const flexRow = css`
 	flex-direction: row;
 `;
 
-export const Row = styled.div`
+const Row = styled.div`
 	${flexRow};
 	justify-content: space-between;
 `;
 
-export const Label = styled.label<{ $faded?: boolean }>`
+const Label = styled.label<{ $faded?: boolean }>`
 	position: relative;
 	${flexColumn};
 	align-items: stretch;
@@ -74,7 +74,8 @@ export const Label = styled.label<{ $faded?: boolean }>`
 			}
 		`}
 `;
-export const Fields = styled.fieldset`
+
+const Fields = styled.fieldset`
 	position: relative;
 	${flexRow};
 	padding: 0;
@@ -88,7 +89,7 @@ export const Fields = styled.fieldset`
 
 // TODO: these match the styling from Task in NewActivity, so they should be
 // extracted to a shared snippet.
-export const AllDay = styled.label`
+const AllDay = styled.label`
 	${flexRow};
 	align-items: center;
 	width: max-content;
@@ -114,14 +115,14 @@ export const AllDay = styled.label`
 	}
 `;
 
-export const Checkbox = styled.input`
+const Checkbox = styled.input`
 	outline: none;
 	border: none;
 	width: 0px;
 	height: 0px;
 `;
 
-export const Icon = styled.span`
+const Icon = styled.span`
 	border: none;
 	width: 30px;
 	display: flex;
@@ -137,7 +138,7 @@ export const Icon = styled.span`
 `;
 
 const size = "25px";
-export const Info = styled.div`
+const Info = styled.div`
 	position: absolute;
 	top: calc(50% -${size});
 	right: calc(-0.25 * ${size});
@@ -151,3 +152,14 @@ export const Info = styled.div`
 	color: white;
 	outline: 2px solid white;
 `;
+
+export default {
+	Form,
+	Row,
+	Label,
+	Fields,
+	AllDay,
+	Checkbox,
+	Icon,
+	Info
+};

--- a/client/src/components/NewActivity/DateTimePicker.style.ts
+++ b/client/src/components/NewActivity/DateTimePicker.style.ts
@@ -43,7 +43,7 @@ export const Label = styled.label<{ $faded?: boolean }>`
 	}
 
 	span {
-		font-size: 0.9rem;
+		font-size: ${(p) => p.theme.font.size["0.9"]};
 		background-color: #fff;
 		width: 100%;
 		padding: 0.2rem 0.6rem;
@@ -132,7 +132,7 @@ export const Icon = styled.span`
 	}
 
 	.on {
-		color: forestgreen;
+		color: ${(p) => p.theme.colors.green.main};
 	}
 `;
 

--- a/client/src/components/NewActivity/DateTimePicker.tsx
+++ b/client/src/components/NewActivity/DateTimePicker.tsx
@@ -1,7 +1,7 @@
 import { Checkbox } from "@lib/theme/components/Checkbox";
 import { FaInfo } from "react-icons/fa";
 import type { DateTimePickerProps } from "./datetime-picker.types";
-import * as S from "./DateTimePicker.style";
+import S from "./DateTimePicker.style";
 import useDateTimePicker from "./useDateTimePicker";
 
 export default function DateTimePicker({ setState }: DateTimePickerProps) {

--- a/client/src/components/NewActivity/NewActivity.style.tsx
+++ b/client/src/components/NewActivity/NewActivity.style.tsx
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import { inputStyle } from "@lib/theme/snippets/input";
 import styled, { css } from "styled-components";
 
@@ -55,7 +56,7 @@ export const Button = styled.button`
 	margin-top: 0.3rem;
 	align-self: center;
 	width: max-content;
-	font-size: 0.9rem;
+	font-size: ${(p) => getFontSize(p, 0.9)};
 	background-color: #ddd;
 	border-radius: 5px;
 	border: 2px solid transparent;
@@ -73,7 +74,7 @@ export const Button = styled.button`
 `;
 
 export const Label = styled.label<{ $showWarning?: boolean }>`
-	font-size: 0.9rem;
+	font-size: ${(p) => getFontSize(p, 0.9)};
 
 	display: flex;
 	flex-direction: column;
@@ -93,7 +94,7 @@ export const Label = styled.label<{ $showWarning?: boolean }>`
 		background-color: #fff;
 		padding: 0.2rem 0.6rem;
 		border-radius: 0 15px 0 0;
-		font-size: 0.9rem;
+		font-size: ${(p) => getFontSize(p, 0.9)};
 	}
 
 	input {
@@ -132,7 +133,7 @@ export const Task = styled.label`
 		justify-self: center;
 
 		&.on {
-			color: forestgreen;
+			color: ${(p) => p.theme.colors.green.main};
 		}
 
 		&.off {

--- a/client/src/components/NewActivity/NewActivity.style.tsx
+++ b/client/src/components/NewActivity/NewActivity.style.tsx
@@ -11,7 +11,7 @@ export const Wrapper = styled.div`
 	max-width: 500px;
 
 	h1 {
-		font-size: 1.1rem;
+		font-size: ${(p) => getFontSize(p, 1.1)};
 		margin: 0;
 		margin-left: 0.8rem;
 		margin-top: -1.5rem;

--- a/client/src/components/NewActivity/useNewActivity.ts
+++ b/client/src/components/NewActivity/useNewActivity.ts
@@ -35,7 +35,7 @@ export default function useNewActivity() {
 			{ activity: parseNewActivity(newActivity), tagIds: selectedTagIds },
 			{
 				onSuccess: () => {
-					navigate("/activities"); // TODO: put routes in a variable
+					navigate("/today"); // TODO: put routes in a variable
 				}
 			}
 		);

--- a/client/src/components/NewNote/NewNote.style.tsx
+++ b/client/src/components/NewNote/NewNote.style.tsx
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import { inputStyle } from "@lib/theme/snippets/input";
 import { styled } from "styled-components";
 
@@ -17,7 +18,7 @@ export const Title = styled.h2`
 	margin-top: -1.5rem;
 	margin-left: 0.2rem;
 	margin-bottom: 0.6rem;
-	font-size: 1.2rem;
+	font-size: ${(p) => getFontSize(p, 1.2)};
 	border: 2px solid #ccc;
 	border-radius: 2px;
 	padding: 0.2rem 0.8rem;

--- a/client/src/components/NewTag/NewTag.style.tsx
+++ b/client/src/components/NewTag/NewTag.style.tsx
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import { inputStyle } from "@lib/theme/snippets/input";
 import styled from "styled-components";
 
@@ -18,7 +19,7 @@ export const Form = styled.section`
 		margin-left: 0.2rem;
 		margin-bottom: 0.6rem;
 
-		font-size: 1.2rem;
+		font-size: ${(p) => getFontSize(p, 1.2)};
 
 		border: 2px solid #ccc;
 		border-radius: 2px;

--- a/client/src/components/NewTag/NewTag.tsx
+++ b/client/src/components/NewTag/NewTag.tsx
@@ -34,14 +34,16 @@ function NewTag({ modalId }: NewTagProps) {
 					/>
 				</S.Field>
 
-				<S.Tags>
-					<TagSelector
-						title="Categorize"
-						maximum={1}
-						tagsById={tags?.tagsById}
-						modalId={modalId}
-					/>
-				</S.Tags>
+				{Object.keys(tags?.tagsById ?? {}).length > 0 && (
+					<S.Tags>
+						<TagSelector
+							title="Categorize"
+							maximum={1}
+							tagsById={tags?.tagsById}
+							modalId={modalId}
+						/>
+					</S.Tags>
+				)}
 				<S.Button title="Save">💾</S.Button>
 			</S.Fields>
 		</S.Form>

--- a/client/src/components/Notes/Notes.style.tsx
+++ b/client/src/components/Notes/Notes.style.tsx
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import { styled } from "styled-components";
 
 export const Page = styled.section`
@@ -33,7 +34,7 @@ export const Note = styled.li`
 `;
 
 export const Title = styled.h2`
-	font-size: 1.02rem;
+	font-size: ${(p) => getFontSize(p, 1.02)};
 	padding: 0.3rem 0.7rem;
 	background-color: #eee;
 	border: 2px solid #ccc;
@@ -53,7 +54,7 @@ export const Tags = styled.ul`
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0.1rem;
-	font-size: 0.75rem;
+	font-size: ${(p) => getFontSize(p, 0.75)};
 `;
 
 export const Tag = styled.li`

--- a/client/src/components/Notes/Notes.tsx
+++ b/client/src/components/Notes/Notes.tsx
@@ -29,9 +29,7 @@ function NoteElement({ note, tags }: { note: NoteWithIds; tags?: TagsData }) {
 export default function Notes() {
 	const { notes, tags } = useNotes();
 
-	if (!notes?.notesById) {
-		return <></>;
-	}
+	if (!notes?.notesById) return <></>;
 
 	return (
 		<S.Page>

--- a/client/src/components/TagCard/TagCard.style.tsx
+++ b/client/src/components/TagCard/TagCard.style.tsx
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import styled from "styled-components";
 
 export const Tag = styled.div`
@@ -6,6 +7,6 @@ export const Tag = styled.div`
 	background-color: darkorchid;
 	color: azure;
 	max-width: max-content;
-	font-size: 0.9rem;
+	font-size: ${(p) => getFontSize(p, 0.9)};
 	user-select: none; //  TODO: when tags become clickable, this disappears; use a button insted
 `;

--- a/client/src/components/TagSelector/NewTagButton.style.ts
+++ b/client/src/components/TagSelector/NewTagButton.style.ts
@@ -32,10 +32,10 @@ export const Button = styled.button<{
 	transition: all 25ms linear;
 
 	&:hover {
-		background-color: forestgreen;
+		background-color: ${(p) => p.theme.colors.green.main};
 		box-shadow: 0 0.8rem 0 -0.6rem #ddd;
 		/* transform: translateX(5px); */
-		border-bottom-color: limegreen;
+		border-bottom-color: ${(p) => p.theme.colors.green.secondary};
 	}
 `;
 

--- a/client/src/components/TagSelector/TagSelector.style.ts
+++ b/client/src/components/TagSelector/TagSelector.style.ts
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import styled, { css } from "styled-components";
 
 const Wrapper = styled.div<{ $fullSize?: boolean }>`
@@ -43,7 +44,7 @@ const ListItem = styled.li<{ $hasParent?: boolean; $isSelected?: boolean }>`
 	border-radius: 2px;
 	box-shadow: 0.2rem 0.1rem 0 0 #ddd;
 	padding: 0.2rem 0.6rem;
-	font-size: 0.82rem;
+	font-size: ${(p) => getFontSize(p, 0.82)};
 	min-height: calc(4px + 1.24rem); // should be font-size + padding + border
 	height: max-content;
 
@@ -89,7 +90,7 @@ const Title = styled.h3`
 	background-color: #333;
 	color: azure;
 	max-width: max-content;
-	font-size: 1.1rem;
+	font-size: ${(p) => getFontSize(p, 1.1)};
 
 	border-radius: 3px;
 	border: 2px solid #777;
@@ -105,8 +106,9 @@ const Filter = styled.input`
 	align-self: flex-end;
 	max-width: 150px;
 
-	font-size: 0.88rem;
-	line-height: 0.88rem;
+	--font-size: ${(p) => getFontSize(p, 0.88)};
+	font-size: var(--font-size);
+	line-height: var(--font-size);
 
 	&:focus {
 		outline-color: ${(p) => p.theme.colors.blue.main};
@@ -248,7 +250,7 @@ const SelectionList = styled.ul`
 	flex-direction: row;
 	flex-wrap: wrap;
 	gap: 0.5rem;
-	font-size: 0.85rem;
+	font-size: ${(p) => getFontSize(p, 0.85)};
 	align-items: center;
 	user-select: none;
 	max-height: 120px;

--- a/client/src/components/TagSelector/TagSelector.style.ts
+++ b/client/src/components/TagSelector/TagSelector.style.ts
@@ -109,7 +109,7 @@ const Filter = styled.input`
 	line-height: 0.88rem;
 
 	&:focus {
-		outline-color: dodgerblue;
+		outline-color: ${(p) => p.theme.colors.blue.main};
 		box-shadow: 0rem 0.5rem 0.2rem -0.2rem #ccc;
 	}
 `;
@@ -187,7 +187,7 @@ const DropdownTrigger = styled.button`
 	}
 
 	&:focus:not(:active) {
-		outline: 2px solid dodgerblue;
+		outline: 2px solid ${(p) => p.theme.colors.blue.main};
 		background-color: #fff;
 	}
 
@@ -262,7 +262,7 @@ const SelectionItem = styled.li`
 	min-width: max-content;
 	flex: 1;
 	border-radius: 4px;
-	background-color: dodgerblue;
+	background-color: ${(p) => p.theme.colors.blue.main};
 	color: white;
 	justify-content: center;
 	align-items: center;
@@ -284,7 +284,7 @@ const PathPart = styled.span<{ $isLeaf: boolean }>`
 const EmptySelection = styled.div`
 	padding: 0.4rem 1.2rem;
 	color: azure;
-	background-color: dodgerblue;
+	background-color: ${(p) => p.theme.colors.blue.main};
 	max-width: max-content;
 	margin-top: 0.5rem;
 `;

--- a/client/src/components/TagSelector/TagSelector.style.ts
+++ b/client/src/components/TagSelector/TagSelector.style.ts
@@ -14,7 +14,7 @@ const Wrapper = styled.div<{ $fullSize?: boolean }>`
 
 	max-width: ${(p) => (p.$fullSize ? "100%" : "400px")};
 
-	min-height: 120px; // TODO: this is hardcoded for the current size to prevent layout shift -- should be dynamic
+	min-height: 130px; // TODO: this is hardcoded for the current size to prevent layout shift -- should be dynamic
 `;
 
 const List = styled.ul`

--- a/client/src/components/TagSelector/TagSelector.tsx
+++ b/client/src/components/TagSelector/TagSelector.tsx
@@ -63,14 +63,11 @@ export default function TagSelector(p: TagSelectorProps) {
 						)}
 					</S.Actions>
 
-					{!f.expanded &&
-						(!t.selectedTags.length ? (
-							<S.EmptySelection>
-								You haven't selected any tags yet.
-							</S.EmptySelection>
-						) : (
-							<Selection tags={t.tags} selectedTags={t.selectedTags} />
-						))}
+					{!t.selectedTags.length ? (
+						<S.EmptySelection>You haven't selected any tags yet.</S.EmptySelection>
+					) : (
+						<Selection tags={t.tags} selectedTags={t.selectedTags} />
+					)}
 
 					{f.expanded && (
 						<S.DropdownContent ref={f.dropdownRef}>
@@ -101,6 +98,7 @@ export default function TagSelector(p: TagSelectorProps) {
 
 							<S.List>
 								<TagSelectorItems
+									modalId={p.modalId}
 									tags={t.tagsToDisplay}
 									tagSelection={t.tagSelection}
 									updateTagSelection={t.updateTagSelection}

--- a/client/src/components/TagSelector/TagSelectorItems.tsx
+++ b/client/src/components/TagSelector/TagSelectorItems.tsx
@@ -2,6 +2,8 @@ import type {
 	TagSelectorItemProps,
 	TagSelectorItemsProps
 } from "@/components/TagSelector/tag-selector.types";
+import useTagsQuery from "@/lib/query/useTagsQuery";
+import { useModalState } from "@/lib/state/modal-state";
 import S from "./TagSelector.style";
 
 function TagSelectorItem(p: TagSelectorItemProps) {
@@ -21,6 +23,40 @@ function TagSelectorItem(p: TagSelectorItemProps) {
 }
 
 function TagSelectorItems(p: TagSelectorItemsProps) {
+	const { openModal } = useModalState(p.modalId);
+	const { data } = useTagsQuery();
+
+	if (data?.tagsById && Object.keys(data.tagsById).length > 0 && p.tags.length === 0) {
+		return <p>No tags found for selected filter.</p>;
+	}
+
+	if (data?.tagsById && Object.keys(data.tagsById).length === 0)
+		return (
+			<button
+				type="button"
+				onClick={(e) => {
+					openModal();
+					e.stopPropagation();
+				}}
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					gap: "1rem",
+					width: "100%",
+					justifyContent: "center",
+					textDecoration: "underline",
+					backgroundColor: "dodgerblue",
+					color: "white",
+					border: "none",
+					alignItems: "center",
+					padding: "0.5rem",
+					height: "max-content"
+				}}
+			>
+				You do not have any tags yet. Click to add one.
+			</button>
+		);
+
 	return p.tags.map((tag) => (
 		<TagSelectorItem
 			tagSelection={p.tagSelection}

--- a/client/src/components/TagSelector/tag-selector.types.ts
+++ b/client/src/components/TagSelector/tag-selector.types.ts
@@ -14,6 +14,7 @@ export type TagSelectorItemProps = SubcomponentProps & {
 
 export type TagSelectorItemsProps = SubcomponentProps & {
 	tags: TagWithIds[];
+	modalId: string;
 };
 
 export type FilterProps = {

--- a/client/src/components/TagTree/TagTree.style.tsx
+++ b/client/src/components/TagTree/TagTree.style.tsx
@@ -100,6 +100,7 @@ export const Tree = styled.ul<{
 	gap: 2rem;
 
 	> ${Tag} {
+		min-width: 150px; // TODO: this is temporary and needs to become responsive
 		height: 98%;
 		justify-content: flex-start;
 		width: max-content;

--- a/client/src/components/TagTree/TagTree.style.tsx
+++ b/client/src/components/TagTree/TagTree.style.tsx
@@ -1,4 +1,5 @@
 import BadgeStyles from "@/lib/theme/components/Badge.style";
+import { getFontSize } from "@/lib/theme/font";
 import { motion } from "framer-motion";
 import styled, { css } from "styled-components";
 
@@ -6,7 +7,7 @@ const borderColors = ["#444", "#777", "#aaa", "#ddd"];
 const colors = ["deepskyblue", "blueviolet", "darkorchid", "darkviolet", "indigo"];
 
 export const TagName = styled.label<{ $level: number }>`
-	font-size: 0.9rem;
+	font-size: ${(p) => getFontSize(p, 0.9)};
 	min-width: 50px;
 	position: relative;
 

--- a/client/src/components/TagTree/TagTree.tsx
+++ b/client/src/components/TagTree/TagTree.tsx
@@ -34,12 +34,6 @@ export default function TagTree({
 			<div>
 				<S.Container>
 					<h1>Tag tree</h1>
-					<div>
-						<label>
-							filter
-							<input type="text" />
-						</label>
-					</div>
 					<S.Tree $orientation={orientation} $columnCount={rootTags.length}>
 						{rootTags.map((tag) => (
 							<Tag key={tag.tag_id} tag={tag} level={0} />

--- a/client/src/components/Today/Empty.tsx
+++ b/client/src/components/Today/Empty.tsx
@@ -1,0 +1,6 @@
+import type { PropsWithChildren } from "react";
+import E from "./style/Empty.style";
+
+export default function Empty({ children }: PropsWithChildren) {
+	return <E.Empty>{children}</E.Empty>;
+}

--- a/client/src/components/Today/Notes.tsx
+++ b/client/src/components/Today/Notes.tsx
@@ -1,3 +1,4 @@
+import Empty from "@/components/Today/Empty";
 import { filterTagsById } from "@/lib/filter-tags";
 import useNotesQuery from "@/lib/query/useNotesQuery";
 import useTagsQuery from "@/lib/query/useTagsQuery";
@@ -18,6 +19,7 @@ export default function Notes() {
 	return (
 		<S.NotesWrapper>
 			<S.BlockTitle>Notes</S.BlockTitle>
+			{!notes.length && <Empty>No notes found for today.</Empty>}
 			{notes.map((n) => (
 				<Note
 					key={n.note_id}

--- a/client/src/components/Today/Tasks.tsx
+++ b/client/src/components/Today/Tasks.tsx
@@ -1,3 +1,4 @@
+import Empty from "@/components/Today/Empty";
 import { filterTagsById } from "@/lib/filter-tags";
 import useTagsQuery from "@/lib/query/useTagsQuery";
 import type { ActivityWithIds } from "@type/server/activity.types";
@@ -16,6 +17,8 @@ export default function Tasks({ activities }: TasksProps) {
 		<T.TasksWrapper>
 			<S.BlockTitle>Tasks</S.BlockTitle>
 			<T.Tasks>
+				{!activities.length && <Empty>No tasks found for today.</Empty>}
+
 				{activities.map((a) => (
 					<Task
 						key={a.activity_id}

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -64,7 +64,9 @@ export default function Today() {
 					<S.Header>
 						<h1>{t.currentDate.format("dddd (DD MMMM)")}</h1>
 					</S.Header>
-					<AllDayActivities activities={t.allDayActivities} />
+					{!!t.allDayActivities.length && (
+						<AllDayActivities activities={t.allDayActivities} />
+					)}
 					<TimelineRows
 						activities={t.timestampedActivities}
 						currentDate={t.currentDate}

--- a/client/src/components/Today/style/Activity.style.ts
+++ b/client/src/components/Today/style/Activity.style.ts
@@ -1,4 +1,5 @@
 import { rowHeight } from "@/components/Today/style/TimelineRow.style";
+import { getFontSize } from "@/lib/theme/font";
 import { css, styled } from "styled-components";
 import S from "./Today.style";
 
@@ -11,7 +12,7 @@ const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	user-select: none;
 	top: calc(${(p) => p.$offset * 100}%);
 	left: calc(3rem + ${(p) => p.$level * (cardGap + cardWidth)}px);
-	font-size: 0.85rem;
+	font-size: ${(p) => getFontSize(p, 0.85)};
 	display: flex;
 	width: 100%;
 	height: max-content;

--- a/client/src/components/Today/style/Activity.style.ts
+++ b/client/src/components/Today/style/Activity.style.ts
@@ -11,7 +11,7 @@ const ActivityCard = styled.div<{ $level: number; $offset: number }>`
 	user-select: none;
 	top: calc(${(p) => p.$offset * 100}%);
 	left: calc(3rem + ${(p) => p.$level * (cardGap + cardWidth)}px);
-	font-size: 0.86rem;
+	font-size: 0.85rem;
 	display: flex;
 	width: 100%;
 	height: max-content;
@@ -38,6 +38,7 @@ const Activity = styled.div<{
 	padding: 0.5rem 1rem;
 	background-color: ${(p) => (p.$isTask ? "dodgerblue" : "limegreen")};
 	align-items: ${(p) => (p.$durationHours > 2 ? "flex-start" : "center")};
+	color: ${(p) => (p.$isTask ? "azure" : "black")};
 
 	outline: 2px solid #eee;
 	width: ${cardWidth}px;
@@ -57,7 +58,7 @@ const Activity = styled.div<{
 
 	&:hover {
 		z-index: 3;
-		background-color: ${(p) => (p.$isTask ? "royalblue" : "forestgreen")};
+		background-color: ${(p) => (p.$isTask ? "royalblue" : p.theme.colors.green.main)};
 		color: azure;
 	}
 `;

--- a/client/src/components/Today/style/AllDayActivity.style.ts
+++ b/client/src/components/Today/style/AllDayActivity.style.ts
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import styled from "styled-components";
 import S from "./Today.style";
 
@@ -9,7 +10,7 @@ const AllDayActivity = styled.li`
 	background-color: dodgerblue;
 	color: white;
 	padding: 0.2rem 1rem;
-	font-size: 0.93rem;
+	font-size: ${(p) => getFontSize(p, 0.93)};
 	border-radius: 3px;
 	outline: 2px solid dodgerblue;
 	box-shadow: 0 0.2rem 0.3rem 0 #aaa;

--- a/client/src/components/Today/style/CurrentTimeMark.style.ts
+++ b/client/src/components/Today/style/CurrentTimeMark.style.ts
@@ -7,7 +7,7 @@ const Circle = styled.div`
 	z-index: 4;
 	border-radius: 50%;
 	position: absolute;
-	left: 0;
+	right: 0;
 	--size: 15px;
 	top: calc(50% - var(--size) / 2);
 	min-height: var(--size);

--- a/client/src/components/Today/style/DetailedActivity.style.tsx
+++ b/client/src/components/Today/style/DetailedActivity.style.tsx
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import styled from "styled-components";
 
 const Wrapper = styled.section`
@@ -24,6 +25,7 @@ const Title = styled.h2`
 	}
 	grid-area: title;
 	font-size: 1.5rem;
+	line-height: 2rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
 	background-color: indigo;
@@ -57,7 +59,7 @@ const Datetime = styled.div`
 `;
 
 const HumanizedStart = styled.p`
-	font-size: 0.9rem;
+	font-size: ${(p) => getFontSize(p, 0.9)};
 	line-height: 0.92rem;
 	color: azure;
 	background-color: darkorchid;
@@ -116,7 +118,7 @@ const CheckboxWrapper = styled.label`
 		background-color: azure;
 
 		&.on {
-			fill: forestgreen;
+			fill: ${(p) => p.theme.colors.green.main};
 			color: white;
 		}
 

--- a/client/src/components/Today/style/DetailedActivity.style.tsx
+++ b/client/src/components/Today/style/DetailedActivity.style.tsx
@@ -24,7 +24,7 @@ const Title = styled.h2`
 		text-overflow: ellipsis;
 	}
 	grid-area: title;
-	font-size: 1.5rem;
+	font-size: ${(p) => getFontSize(p, 1.5)};
 	line-height: 2rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
@@ -52,7 +52,7 @@ const Datetime = styled.div`
 	width: max-content;
 	flex-direction: column;
 	align-items: flex-end;
-	font-size: 0.8rem;
+	font-size: ${(p) => getFontSize(p, 0.8)};
 	margin-top: 0.3rem;
 	color: #888;
 	margin-left: 0.3rem;
@@ -79,7 +79,7 @@ const Tags = styled.ul`
 	grid-area: tags;
 	margin-top: 0.5rem;
 	gap: 0.4rem;
-	font-size: 0.85rem;
+	font-size: ${(p) => getFontSize(p, 0.85)};
 	margin-left: auto;
 `;
 

--- a/client/src/components/Today/style/Empty.style.ts
+++ b/client/src/components/Today/style/Empty.style.ts
@@ -5,6 +5,7 @@ const Empty = styled.p`
 	color: ${(p) => p.theme.colors.white};
 	padding: 0.5rem 1rem;
 	border-radius: 3px;
+	max-width: max-content;
 `;
 
 export default {

--- a/client/src/components/Today/style/Empty.style.ts
+++ b/client/src/components/Today/style/Empty.style.ts
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+const Empty = styled.p`
+	background-color: ${(p) => p.theme.colors.highlight.info};
+	color: ${(p) => p.theme.colors.white};
+	padding: 0.5rem 1rem;
+	border-radius: 3px;
+`;
+
+export default {
+	Empty
+};

--- a/client/src/components/Today/style/HourMark.style.ts
+++ b/client/src/components/Today/style/HourMark.style.ts
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import styled, { css } from "styled-components";
 
 const HourMark = styled.span<{ $highlighted?: boolean }>`
@@ -10,7 +11,7 @@ const HourMark = styled.span<{ $highlighted?: boolean }>`
 	height: var(--size);
 	top: calc(-1 * var(--size) / 2);
 	left: -1rem;
-	font-size: 0.75rem;
+	font-size: ${(p) => getFontSize(p, 0.75)};
 	width: max-content;
 	border-radius: 3px;
 	padding: 0 0.5rem;

--- a/client/src/components/Today/style/Tasks.style.ts
+++ b/client/src/components/Today/style/Tasks.style.ts
@@ -2,8 +2,10 @@ import { column } from "@/components/Today/style/Today.style";
 import { getFontSize } from "@/lib/theme/font";
 import styled from "styled-components";
 
+// TODO: make this shared with Notes for now since they are currently the same
 const TasksWrapper = styled.section`
 	${column};
+	padding: 0 1rem;
 `;
 
 const TaskName = styled.div`
@@ -35,7 +37,7 @@ const Tasks = styled.ul`
 	flex-direction: column;
 	gap: 0.6rem;
 	overflow-x: auto;
-	margin: 0 0.5rem;
+	padding: 0 0.5rem;
 	max-width: 720px;
 	height: 100%; // TODO: only apply this when in list/column view?
 `;

--- a/client/src/components/Today/style/Tasks.style.ts
+++ b/client/src/components/Today/style/Tasks.style.ts
@@ -27,7 +27,7 @@ const Times = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;
-	font-size: 0.8rem;
+	font-size: ${(p) => getFontSize(p, 0.8)};
 
 	color: #555;
 `;

--- a/client/src/components/Today/style/Tasks.style.ts
+++ b/client/src/components/Today/style/Tasks.style.ts
@@ -1,6 +1,10 @@
+import { column } from "@/components/Today/style/Today.style";
+import { getFontSize } from "@/lib/theme/font";
 import styled from "styled-components";
 
-const TasksWrapper = styled.section``;
+const TasksWrapper = styled.section`
+	${column};
+`;
 
 const TaskName = styled.div`
 	display: flex;
@@ -41,7 +45,7 @@ const Task = styled.li`
 	list-style: none;
 	cursor: pointer;
 	box-sizing: border-box;
-	font-size: 0.9rem;
+	font-size: ${(p) => getFontSize(p, 0.9)};
 	display: grid;
 
 	grid-template-columns: max-content min-content max-content auto;

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -8,6 +8,12 @@ const TimelineWrapper = styled.section`
 	flex-direction: column;
 	gap: 1.5rem;
 	padding: 1rem 3rem;
+
+	max-width: 100%;
+	min-width: 500px;
+	@media (min-width: 1280px) {
+		width: 700px;
+	}
 `;
 
 export const column = css`
@@ -17,14 +23,15 @@ export const column = css`
 `;
 
 const Column = styled.section`
-	${column}
+	${column};
+	padding: 0 1rem;
 `;
 
 const NotesWrapper = styled(Column)``;
 
 const BlockTitle = styled.h2`
 	width: max-content;
-	padding: 0.5rem 1rem;
+	padding: 0.5rem 0;
 `;
 
 const Rows = styled.ul`
@@ -59,7 +66,7 @@ const Columns = styled.div`
 	display: grid;
 
 	@media (min-width: 1280px) {
-		grid-template-columns: max-content 1fr max-content auto; // TODO: this is still temporary because the whole layout is temporary
+		grid-template-columns: max-content auto max-content auto; // TODO: this is still temporary because the whole layout is temporary
 	}
 
 	grid-template-columns: 1fr;

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -1,5 +1,5 @@
 import { Tag } from "@/components/TagCard/TagCard.style";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 const Wrapper = styled.div``;
 
@@ -10,7 +10,17 @@ const TimelineWrapper = styled.section`
 	padding: 1rem 3rem;
 `;
 
-const NotesWrapper = styled.section``;
+export const column = css`
+	@media (min-width: 1280px) {
+		min-width: 350px;
+	}
+`;
+
+const Column = styled.section`
+	${column}
+`;
+
+const NotesWrapper = styled(Column)``;
 
 const BlockTitle = styled.h2`
 	width: max-content;
@@ -31,7 +41,7 @@ const CheckboxWrapper = styled.label`
 	height: 27px;
 
 	.on {
-		fill: forestgreen;
+		fill: ${(p) => p.theme.colors.green.main};
 	}
 
 	.off {
@@ -58,14 +68,18 @@ const Columns = styled.div`
 `;
 
 const Header = styled.header`
-	padding: 1rem 3rem;
-	padding-bottom: 0.5rem;
+	padding: 1rem 0;
 
+	// this is the element that displays the date
 	h1 {
-		// this is the element that displays the date
-		font-size: 2rem;
+		font-size: 1.2rem;
+		@media (min-width: 1440px) {
+			font-size: 2rem;
+		}
 		font-weight: 400;
 		margin: 0;
+		padding: 0;
+		width: max-content;
 	}
 `; // is a header the right tag, semantically?
 

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -1,4 +1,5 @@
 import { Tag } from "@/components/TagCard/TagCard.style";
+import { getFontSize } from "@/lib/theme/font";
 import styled, { css } from "styled-components";
 
 const Wrapper = styled.div``;
@@ -79,9 +80,9 @@ const Header = styled.header`
 
 	// this is the element that displays the date
 	h1 {
-		font-size: 1.2rem;
+		font-size: ${(p) => getFontSize(p, 1.2)};
 		@media (min-width: 1440px) {
-			font-size: 2rem;
+			font-size: ${(p) => getFontSize(p, 2)};
 		}
 		font-weight: 400;
 		margin: 0;

--- a/client/src/lib/theme/colors.ts
+++ b/client/src/lib/theme/colors.ts
@@ -1,4 +1,33 @@
-export const colors = {
-	black: "#000",
-	white: "#fff"
-} as const;
+const baseColors = {
+	blue: {
+		main: "dodgerblue",
+		secondary: "deepskyblue"
+	},
+	yellow: {
+		main: "gold",
+		secondary: "orange"
+	},
+	red: {
+		main: "tomato",
+		secondary: "orangered"
+	},
+	green: {
+		main: "forestgreen",
+		secondary: "limegreen"
+	},
+	black: "black",
+	white: "white"
+};
+
+const highlightColors = {
+	primary: baseColors.yellow.main,
+	secondary: baseColors.red.secondary,
+	success: baseColors.green.main,
+	info: baseColors.blue.main,
+	warning: baseColors.red.secondary,
+	danger: baseColors.red.main,
+	light: "azure",
+	dark: "#333"
+};
+
+export const colors = { ...baseColors, highlight: highlightColors };

--- a/client/src/lib/theme/components/Badge.style.ts
+++ b/client/src/lib/theme/components/Badge.style.ts
@@ -1,3 +1,4 @@
+import { getFontSize } from "@/lib/theme/font";
 import styled from "styled-components";
 import type { CSS } from "styled-components/dist/types";
 
@@ -5,7 +6,7 @@ const Badge = styled.div<{ height?: CSS.Properties["height"] }>`
 	display: flex;
 	place-items: center;
 	border-radius: 8px;
-	font-size: 0.82rem;
+	font-size: ${(p) => getFontSize(p, 0.82)};
 
 	background-color: ${(p) => p.color ?? "#ccc"};
 	width: max-content;

--- a/client/src/lib/theme/font.ts
+++ b/client/src/lib/theme/font.ts
@@ -1,7 +1,7 @@
 import type { MainTheme } from "@/lib/theme/theme";
 
 const fontSizes = [
-	0.75, 0.8, 0.82, 0.85, 0.86, 0.88, 0.9, 0.93, 1, 1.02, 1.1, 1.2, 1.5, 2
+	0.75, 0.8, 0.82, 0.85, 0.86, 0.88, 0.9, 0.93, 1, 1.02, 1.1, 1.2, 1.35, 1.5, 2
 ] as const;
 
 // TODO: looks hacky, but works

--- a/client/src/lib/theme/font.ts
+++ b/client/src/lib/theme/font.ts
@@ -1,0 +1,22 @@
+import type { MainTheme } from "@/lib/theme/theme";
+
+const fontSizes = [
+	0.75, 0.8, 0.82, 0.85, 0.86, 0.88, 0.9, 0.93, 1, 1.02, 1.1, 1.2, 1.5, 2
+] as const;
+
+// TODO: looks hacky, but works
+type FontSize = Record<(typeof fontSizes)[number], `${(typeof fontSizes)[number]}rem`>;
+
+const size = fontSizes.reduce((acc, size) => {
+	acc[size] = `${size}rem`;
+	return acc;
+}, {} as FontSize);
+
+export const font = {
+	size
+};
+
+type Props = object & { theme: MainTheme };
+export function getFontSize({ theme }: Props, size: keyof FontSize) {
+	return theme.font.size[size];
+}

--- a/client/src/lib/theme/snippets/input.ts
+++ b/client/src/lib/theme/snippets/input.ts
@@ -1,7 +1,8 @@
+import { font } from "@/lib/theme/font";
 import { css } from "styled-components";
 
 export const inputStyle = css`
-	font-size: 0.93rem;
+	font-size: ${font.size[0.93]};
 	outline: none;
 	border: none;
 	padding: 0.3rem 0.5rem;

--- a/client/src/lib/theme/snippets/input.ts
+++ b/client/src/lib/theme/snippets/input.ts
@@ -1,7 +1,7 @@
 import { css } from "styled-components";
 
 export const inputStyle = css`
-	font-size: 0.94rem;
+	font-size: 0.93rem;
 	outline: none;
 	border: none;
 	padding: 0.3rem 0.5rem;

--- a/client/src/lib/theme/theme.ts
+++ b/client/src/lib/theme/theme.ts
@@ -1,5 +1,7 @@
+import { font } from "@/lib/theme/font.ts";
 import { colors } from "./colors.ts";
 export const theme = {
-	colors
+	colors,
+	font
 } as const;
 export type MainTheme = typeof theme;

--- a/client/src/types/theme.d.ts
+++ b/client/src/types/theme.d.ts
@@ -1,4 +1,4 @@
-import type { MainTheme } from "../helpers/theme/theme";
+import type { MainTheme } from "@/lib/theme/theme";
 declare module "styled-components" {
 	// eslint-disable-next-line @typescript-eslint/no-empty-interface
 	export interface DefaultTheme extends MainTheme {}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "`npm run dev` on the client to start the vite dev server.",
   "main": "index.js",
   "scripts": {
-    "dev": "cd ./docker && docker-compose --file ./dev.yml up --force-recreate --remove-orphans",
+    "dev": "cd ./docker && docker-compose --file ./dev.yml up --build --force-recreate --remove-orphans",
     "prod": "cd ./docker && docker-compose --file ./docker-compose.prod.yml up --force-recreate --remove-orphans --build server database store test-database",
     "dev-build": "cd ./docker && docker-compose --file ./dev.yml up --force-recreate --remove-orphans --build server database store test-database",
     "dev-down": "cd ./docker && docker-compose --file ./dev.yml down --volumes",


### PR DESCRIPTION
- (style) put all currently-used font sizes in the theme. Eventually we'll extract more generic style atoms/molecules for the various types of text, but for now just not adding any font sizes that aren't already used is a good first step.
- (lint) fix the last few lint errors regarding exporting styled components directly
- (feat) add a small Empty subcomponent to display for Tasks and Notes in Today when there are no tasks or notes to display.
- (tweak) do not try to display certain things in `TagSelector` or `NewTag` when there is nothing to display