### PR TITLE
`byId` refactor

### DIFF
--- a/client/src/components/ActivityList/ActivityList.tsx
+++ b/client/src/components/ActivityList/ActivityList.tsx
@@ -8,12 +8,12 @@ import useActivityList from "./useActivityList";
 export default function ActivityList() {
 	const { activitiesData, tagsData } = useActivityList();
 
-	if (!activitiesData?.activitiesById) {
+	if (!activitiesData?.byId) {
 		return <></>;
 	}
 
-	const activities = Object.values(activitiesData.activitiesById);
-	const tagsById = tagsData?.tagsById;
+	const activities = Object.values(activitiesData.byId);
+	const tagsById = tagsData?.byId;
 
 	return (
 		<S.Wrapper>

--- a/client/src/components/NewNote/NewNote.tsx
+++ b/client/src/components/NewNote/NewNote.tsx
@@ -10,7 +10,7 @@ type NewNoteProps = {
 function NewNote({ inActivity }: NewNoteProps) {
 	const { onInputChange, onSubmit, tagsData } = useNewNote({ inActivity });
 
-	const tagsById = tagsData?.tagsById;
+	const tagsById = tagsData?.byId;
 
 	return (
 		<S.Wrapper>

--- a/client/src/components/NewTag/NewTag.tsx
+++ b/client/src/components/NewTag/NewTag.tsx
@@ -34,12 +34,12 @@ function NewTag({ modalId }: NewTagProps) {
 					/>
 				</S.Field>
 
-				{Object.keys(tags?.tagsById ?? {}).length > 0 && (
+				{Object.keys(tags?.byId ?? {}).length > 0 && (
 					<S.Tags>
 						<TagSelector
 							title="Categorize"
 							maximum={1}
-							tagsById={tags?.tagsById}
+							tagsById={tags?.byId}
 							modalId={modalId}
 						/>
 					</S.Tags>

--- a/client/src/components/Notes/Notes.tsx
+++ b/client/src/components/Notes/Notes.tsx
@@ -17,7 +17,7 @@ function NoteElement({ note, tags }: { note: NoteWithIds; tags?: TagsData }) {
 				<S.Title>{title}</S.Title>
 				<S.Tags>
 					{note.tag_ids?.map((id) => (
-						<S.Tag key={id}>{tags?.tagsById?.[id]?.name}</S.Tag>
+						<S.Tag key={id}>{tags?.byId?.[id]?.name}</S.Tag>
 					))}
 				</S.Tags>
 			</S.NoteHeader>
@@ -29,14 +29,14 @@ function NoteElement({ note, tags }: { note: NoteWithIds; tags?: TagsData }) {
 export default function Notes() {
 	const { notes, tags } = useNotes();
 
-	if (!notes?.notesById) return <></>;
+	if (!notes?.byId) return <></>;
 
 	return (
 		<S.Page>
 			<h1>My notes 📔</h1>
 
 			<S.List>
-				{Object.values(notes.notesById).map((note) => (
+				{Object.values(notes.byId).map((note) => (
 					<NoteElement key={note.note_id} note={note} tags={tags} />
 				))}
 			</S.List>

--- a/client/src/components/Notes/Notes.tsx
+++ b/client/src/components/Notes/Notes.tsx
@@ -17,6 +17,7 @@ function NoteElement({ note, tags }: { note: NoteWithIds; tags?: TagsData }) {
 				<S.Title>{title}</S.Title>
 				<S.Tags>
 					{note.tag_ids?.map((id) => (
+						// TODO: use a helper function to get the tag
 						<S.Tag key={id}>{tags?.byId?.[id]?.name}</S.Tag>
 					))}
 				</S.Tags>

--- a/client/src/components/TagSelector/TagSelectorItems.tsx
+++ b/client/src/components/TagSelector/TagSelectorItems.tsx
@@ -26,11 +26,11 @@ function TagSelectorItems(p: TagSelectorItemsProps) {
 	const { openModal } = useModalState(p.modalId);
 	const { data } = useTagsQuery();
 
-	if (data?.tagsById && Object.keys(data.tagsById).length > 0 && p.tags.length === 0) {
+	if (data?.byId && Object.keys(data.byId).length > 0 && p.tags.length === 0) {
 		return <p>No tags found for selected filter.</p>;
 	}
 
-	if (data?.tagsById && Object.keys(data.tagsById).length === 0)
+	if (data?.byId && Object.keys(data.byId).length === 0)
 		return (
 			<button
 				type="button"

--- a/client/src/components/TagSelector/useTagSelector.ts
+++ b/client/src/components/TagSelector/useTagSelector.ts
@@ -47,7 +47,7 @@ export default function useTagSelector({ maximum, tagsById }: UseTagSelector = {
 
 	// TODO: If tags are passed through props (=p.tagsById), they take priority over all the
 	// user's tags (=t.tags.tagsById), We need to rename the variables to make that clear.
-	const tags = Object.values(tagsById ?? tagsData?.tagsById ?? []);
+	const tags = Object.values(tagsById ?? tagsData?.byId ?? []);
 	const tagsToDisplay = tags.filter((tag) =>
 		tag.name.toLowerCase().includes(filter.toLowerCase())
 	);

--- a/client/src/components/TagTree/TagTree.tsx
+++ b/client/src/components/TagTree/TagTree.tsx
@@ -25,9 +25,9 @@ export default function TagTree({
 
 	if (!tagTreeData || !tagsData) return null;
 
-	const rootTags = Object.keys(tagTreeData.tree).map((id) => tagsData.tagsById[+id]);
+	const rootTags = Object.keys(tagTreeData.byId).map((id) => tagsData.byId[+id]);
 
-	if (!Object.values(tagsData.tagsById).length) return null;
+	if (!Object.values(tagsData.byId).length) return null;
 
 	return (
 		<Modal modalId={modalId} initialOpen={initialOpen}>
@@ -62,7 +62,7 @@ function Tag({ tag, level }: TagProps) {
 		return null;
 	}
 
-	const children = tag.child_ids?.map((id) => getTag(id, tagsData.tagsById));
+	const children = tag.child_ids?.map((id) => getTag(id, tagsData.byId));
 
 	return (
 		<S.Tag $level={level} layout>

--- a/client/src/components/Today/DetailedActivity.tsx
+++ b/client/src/components/Today/DetailedActivity.tsx
@@ -71,10 +71,10 @@ export default function DetailedActivity({ activity }: DetailedActivityProps) {
 					</S.Task>
 				)}
 
-				{tagsData?.tagsById && (
+				{tagsData?.byId && (
 					<S.Tags>
 						{activity.tag_ids.map((id) => (
-							<S.Tag key={id}>{tagsData.tagsById[id].name}</S.Tag>
+							<S.Tag key={id}>{tagsData.byId[id].name}</S.Tag>
 						))}
 					</S.Tags>
 				)}

--- a/client/src/components/Today/Notes.tsx
+++ b/client/src/components/Today/Notes.tsx
@@ -10,7 +10,7 @@ export default function Notes() {
 	const { data: notesData } = useNotesQuery();
 	const { data: tags } = useTagsQuery();
 
-	const notes = Object.values(notesData?.notesById ?? {}).filter((note) =>
+	const notes = Object.values(notesData?.byId ?? {}).filter((note) =>
 		// TODO: note.date is not a field in the client when creating a new note,
 		// so it will always be undefined currently, so using created_at is a
 		// temporary solution.
@@ -21,11 +21,7 @@ export default function Notes() {
 			<S.BlockTitle>Notes</S.BlockTitle>
 			{!notes.length && <Empty>No notes found for today.</Empty>}
 			{notes.map((n) => (
-				<Note
-					key={n.note_id}
-					note={n}
-					tags={filterTagsById(n.tag_ids, tags?.tagsById)}
-				/>
+				<Note key={n.note_id} note={n} tags={filterTagsById(n.tag_ids, tags?.byId)} />
 			))}
 		</S.NotesWrapper>
 	);

--- a/client/src/components/Today/Tasks.tsx
+++ b/client/src/components/Today/Tasks.tsx
@@ -22,7 +22,7 @@ export default function Tasks({ activities }: TasksProps) {
 						<Task
 							key={a.activity_id}
 							activity={a}
-							tags={filterTagsById(a.tag_ids, tags?.tagsById)}
+							tags={filterTagsById(a.tag_ids, tags?.byId)}
 						/>
 					))}
 				</T.Tasks>

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -20,7 +20,7 @@ function useToday() {
 	const [currentDate, setCurrentDate] = useState<Dayjs>(() => today());
 
 	const activities = useMemo(() => {
-		return Object.values(activitiesData?.activitiesById ?? {}); // TODO: should this not be in a useActivities hook or someting?
+		return Object.values(activitiesData?.byId ?? {}); // TODO: should this not be in a useActivities hook or someting?
 	}, [activitiesData]);
 	const todayActivities = activities.filter((activity) => {
 		return activityFallsOnDay(activity, currentDate);

--- a/client/src/lib/query/useActivitiesQuery.ts
+++ b/client/src/lib/query/useActivitiesQuery.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import type { Data } from "@type/query.types";
+import type { DataById } from "@type/query.types";
 import type { ActivityWithIds } from "@type/server/activity.types";
-import type { ById } from "@type/server/utility.types";
 import { makeAuthorizedUrl } from "../fetch/make-authorized-url";
 import { defaultQueryConfig } from "../query-client";
 
@@ -15,7 +14,7 @@ async function getActivities() {
 	return response.json();
 }
 
-type ActivitiesData = Data<"byId", ById<ActivityWithIds>>;
+type ActivitiesData = DataById<ActivityWithIds>;
 
 export default function useActivitiesQuery() {
 	return useQuery<ActivitiesData>({

--- a/client/src/lib/query/useActivitiesQuery.ts
+++ b/client/src/lib/query/useActivitiesQuery.ts
@@ -15,7 +15,7 @@ async function getActivities() {
 	return response.json();
 }
 
-type ActivitiesData = Data<"activitiesById", ById<ActivityWithIds>>;
+type ActivitiesData = Data<"byId", ById<ActivityWithIds>>;
 
 export default function useActivitiesQuery() {
 	return useQuery<ActivitiesData>({

--- a/client/src/lib/query/useNotesQuery.ts
+++ b/client/src/lib/query/useNotesQuery.ts
@@ -1,7 +1,6 @@
+import type { DataById } from "@/types/query.types";
 import { useQuery } from "@tanstack/react-query";
-import type { Data } from "@type/query.types";
 import type { NoteWithIds } from "@type/server/note.types";
-import type { ById } from "@type/server/utility.types";
 import { makeAuthorizedUrl } from "../fetch/make-authorized-url";
 import { defaultQueryConfig } from "../query-client";
 
@@ -15,7 +14,7 @@ async function getNotes() {
 	return response.json();
 }
 
-type NotesData = Data<"byId", ById<NoteWithIds>>;
+type NotesData = DataById<NoteWithIds>;
 
 export default function useNotesQuery() {
 	return useQuery<NotesData>({

--- a/client/src/lib/query/useNotesQuery.ts
+++ b/client/src/lib/query/useNotesQuery.ts
@@ -15,7 +15,7 @@ async function getNotes() {
 	return response.json();
 }
 
-type NotesData = Data<"notesById", ById<NoteWithIds>>;
+type NotesData = Data<"byId", ById<NoteWithIds>>;
 
 export default function useNotesQuery() {
 	return useQuery<NotesData>({

--- a/client/src/lib/query/useTagsTreeQuery.ts
+++ b/client/src/lib/query/useTagsTreeQuery.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import type { Data } from "@type/query.types";
-import type { ById } from "@type/server/utility.types";
+import type { DataById } from "@type/query.types";
 import { makeAuthorizedUrl } from "../fetch/make-authorized-url";
 import { defaultQueryConfig } from "../query-client";
 
@@ -13,7 +12,7 @@ export async function getTagsTree() {
 	return response.json();
 }
 
-type TagsTreeData = Data<"byId", ById<{ members: number[] }>>;
+type TagsTreeData = DataById<{ members: number[] }>;
 
 export default function useTagsTreeQuery() {
 	return useQuery<TagsTreeData>({

--- a/client/src/lib/query/useTagsTreeQuery.ts
+++ b/client/src/lib/query/useTagsTreeQuery.ts
@@ -13,7 +13,7 @@ export async function getTagsTree() {
 	return response.json();
 }
 
-type TagsTreeData = Data<"tree", ById<{ members: number[] }>>;
+type TagsTreeData = Data<"byId", ById<{ members: number[] }>>;
 
 export default function useTagsTreeQuery() {
 	return useQuery<TagsTreeData>({

--- a/client/src/types/data.types.ts
+++ b/client/src/types/data.types.ts
@@ -2,4 +2,4 @@ import type { Data } from "./query.types";
 import type { TagWithIds } from "./server/tag.types";
 import type { ById } from "./server/utility.types";
 
-export type TagsData = Data<"tagsById", ById<TagWithIds>>;
+export type TagsData = Data<"byId", ById<TagWithIds>>;

--- a/client/src/types/data.types.ts
+++ b/client/src/types/data.types.ts
@@ -1,5 +1,4 @@
-import type { Data } from "./query.types";
+import type { DataById } from "./query.types";
 import type { TagWithIds } from "./server/tag.types";
-import type { ById } from "./server/utility.types";
 
-export type TagsData = Data<"byId", ById<TagWithIds>>;
+export type TagsData = DataById<TagWithIds>;

--- a/client/src/types/query.types.ts
+++ b/client/src/types/query.types.ts
@@ -1,2 +1,6 @@
-/** Why do I use this in other projects? */
+import type { ById } from "@/types/server/utility.types";
+
+/** Why do I use this in other projects? This is just an object. */
 export type Data<K extends string, T> = Record<K, T>;
+
+export type DataById<T> = Data<"byId", ById<T>>;

--- a/server/src/routers/data.ts
+++ b/server/src/routers/data.ts
@@ -29,7 +29,7 @@ dataRouter.post("/activity", async (req, res) => {
 dataRouter.get("/tags", isAuthorized, async (req, res) => {
 	const user_id = req.session.user!.user_id; // always exists if we're here, because of middleware
 	const tagsById = await getTagsWithRelations({ user_id });
-	res.json({ tagsById });
+	res.json({ byId: tagsById });
 });
 
 dataRouter.post("/tag", isAuthorized, async (req, res) => {
@@ -48,7 +48,7 @@ dataRouter.get("/tags/tree", isAuthorized, async (req, res) => {
 dataRouter.get("/notes", isAuthorized, async (req, res) => {
 	const user_id = req.session.user!.user_id; // always exists if we're here, because of middleware
 	const notesById = await queryNotesAndRelations({ user_id });
-	res.json({ notesById });
+	res.json({ byId: notesById });
 });
 
 dataRouter.post("/note", isAuthorized, async (req, res) => {
@@ -61,7 +61,7 @@ dataRouter.get("/activities", isAuthorized, async (req, res) => {
 	const user_id = req.session.user!.user_id;
 	const activitiesById = await queryActivitiesAndRelations({ user_id });
 
-	res.json({ activitiesById });
+	res.json({ byId: activitiesById });
 });
 
 dataRouter.put("/task/completion", isAuthorized, async (req, res) => {


### PR DESCRIPTION
Instead of creating a complicated TypeScript helper function that extracts the entries generally, e.g. like 
```
const activities: ActivityWithIds[] = getEntries(activitiesData)
const tasks: TaskWithIds[] = getEntries(tasksData)
```
where the type of `activitiesData` is `{ activitiesById: Record<ID, ActivityWithIds> }` and likewise for `tasksData`,

I've decided that it's much less mental overhead and also less implementation hassle to simply return things like 
```
{ byId: tasksById } 
```
from the backend, that way the `Data` type we use is the only typing we need to do for this, and we never have to think about what properties to use, etc., and we can always expect that `thing.byId` will work for things that come from the backend as objects grouped by ID.

This closes #62 as obsolete.

I also added a `DataById` type to prevent having to rewrite `Data<"byId", ById<ThingWithIds[]>>` over and over.