### PR TITLE
run client locally again

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,5 +1,0 @@
-node_modules
-.git
-.gitignore
-*.md
-dist

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:alpine
-WORKDIR '/app'
-COPY ./package.json ./
-EXPOSE 5173
-COPY . .
-RUN ["npm", "run", "dev"]
-

--- a/client/src/lib/fetch/fetch-constants.ts
+++ b/client/src/lib/fetch/fetch-constants.ts
@@ -1,4 +1,4 @@
-export const baseUrl = import.meta.env.VITE_API_URL; // TODO: use something else in production
+export const baseUrl = "http://localhost:5000"; // TODO: use something else in production
 
 export const postConfig: RequestInit = {
 	method: "POST",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -15,8 +15,6 @@ export default defineConfig({
 		extensions: [".js", ".jsx", ".ts", ".tsx", ".json"]
 	},
 	server: {
-		port: 5173, // use env variable
-		host: true,
 		watch: {
 			usePolling: true
 		}

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -32,18 +32,6 @@ services:
       ports:
          - "5000:5000"
 
-   client:
-      build:
-         context: ../client
-         dockerfile: Dockerfile
-      volumes:
-         - ../client:/track/client
-         - node_modules:/track/client/node_modules
-      ports:
-         - "5173:5173"
-      environment:
-         - VITE_API_URL=http://localhost:5000
-
    test-database:
       image: postgres:14-alpine
       environment:
@@ -60,12 +48,6 @@ services:
          - "5434:5434"
       command: ["postgres", "-p 5434", "-c", "log_statement=all"]
 volumes:
-   node_modules: 
-      driver: local
-      driver_opts:
-         type: none
-         o: bind
-         device: ../client/node_modules
    node_modules_server:
       driver: local
       driver_opts:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "`npm run dev` on the client to start the vite dev server.",
   "main": "index.js",
   "scripts": {
-    "dev": "cd ./docker && docker-compose run client npm i --verbose && docker-compose --file ./compose.yml up --force-recreate --remove-orphans",
+    "dev": "cd ./docker && docker-compose --file ./compose.yml up --build --force-recreate --remove-orphans",
     "prod": "cd ./docker && docker-compose --file ./docker-compose.prod.yml up --force-recreate --remove-orphans --build server database store test-database",
     "dev-build": "cd ./docker && docker-compose --file ./compose.yml up --force-recreate --remove-orphans --build server database store test-database",
     "dev-down": "cd ./docker && docker-compose --file ./compose.yml down --volumes -v",

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:18.12.0-alpine
 
 WORKDIR /track/server
 


### PR DESCRIPTION
Running into a bunch of different issues with containerizing the vite dev server, so I'm going back to running it locally again.
- have to very specifically set up the containers so that the container has the rollup packages specific to linux (I code on Windows)
- even when I finally got the packages to install correctly (which also ran into some bugs because apparently NPM has a standing bug on a recent version of node), the dev server isn't exposing itself on my machine's localhost, no matter which server settings I use in the vite config.