### PR TITLE
integrate habits into `Today`

### DIFF
--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -1,36 +1,7 @@
-import DetailedHabit from "@/components/habits/DetailedHabit/DetailedHabit";
-import Habits from "@/components/habits/HabitEntryItem/Habits";
-import { withSyntheticHabitEntries } from "@/components/habits/HabitEntryItem/synthetic";
-import { createDate } from "@/lib/datetime/make-date";
-import useHabitsData from "@/lib/hooks/useHabitsData";
-import type { TimeWindow } from "@/types/time-window.types";
-import { useMemo } from "react";
-
-// TODO this is just a placeholder
-const timeWindow: TimeWindow = {
-	intervalUnit: "day",
-	startDate: createDate(new Date()).startOf("day"),
-	endDate: createDate(new Date()).add(2, "day")
-};
+import Today from "@/components/Today/Today";
 
 function Home() {
-	const { habitsWithEntriesById } = useHabitsData();
-
-	if (!habitsWithEntriesById) return null;
-	const _habits = useMemo(() => {
-		return withSyntheticHabitEntries(habitsWithEntriesById, timeWindow);
-	}, [habitsWithEntriesById, timeWindow]);
-
-	const habitList = Object.values(_habits);
-	if (!habitList.length) return null;
-
-	return (
-		<>
-			<DetailedHabit habit={habitList[0]} />
-			simulating daily view
-			<Habits habits={_habits} />
-		</>
-	);
+	return <Today />;
 }
 
 export default Home;

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -117,14 +117,17 @@ export default function Today() {
 							<ChangeDayButton type="next" onClick={() => t.changeDay("next")} />
 						</h1>
 					</S.Header>
-					{!!t.allDayActivities.length && (
-						<AllDayActivities activities={t.allDayActivities} />
-					)}
+
 					{!!t.habits && (
 						<S.Habits>
 							<Habits habits={t.habits} />
 						</S.Habits>
 					)}
+
+					{!!t.allDayActivities.length && (
+						<AllDayActivities activities={t.allDayActivities} />
+					)}
+
 					<TimelineRows
 						activities={t.timestampedActivities}
 						currentDate={t.currentDate}

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -120,7 +120,11 @@ export default function Today() {
 					{!!t.allDayActivities.length && (
 						<AllDayActivities activities={t.allDayActivities} />
 					)}
-					{!!t.habits && <Habits habits={t.habits} />}
+					{!!t.habits && (
+						<S.Habits>
+							<Habits habits={t.habits} />
+						</S.Habits>
+					)}
 					<TimelineRows
 						activities={t.timestampedActivities}
 						currentDate={t.currentDate}

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -1,4 +1,5 @@
 import Calendar from "@/components/Calendar/Calendar";
+import Habits from "@/components/habits/HabitEntryItem/Habits";
 import Modal from "@/components/Modal";
 import NewActivity from "@/components/NewActivity/NewActivity";
 import NewHabit from "@/components/NewHabit/NewHabit";
@@ -8,9 +9,11 @@ import DetailedActivity from "@/components/Today/DetailedActivity";
 import { activeItemState } from "@/components/Today/hooks/useDetailedActivityModal";
 import TimelineRows from "@/components/Today/TimelineRows";
 import { today } from "@/lib/datetime/make-date";
+import useHabitsData from "@/lib/hooks/useHabitsData";
 import modalIds from "@/lib/modal-ids";
 import useActivitiesQuery from "@/lib/query/useActivitiesQuery";
 import { useModalState } from "@/lib/state/modal-state";
+import type { TimeWindow } from "@/types/time-window.types";
 import { activityFallsOnDay, isAllDayActivityOnDate } from "@lib/activity";
 import type { Dayjs } from "dayjs";
 import { useMemo, useState } from "react";
@@ -22,8 +25,17 @@ import Tasks from "./Tasks";
 /** Functionality hook for the Today component. */
 function useToday() {
 	const { data: activitiesData } = useActivitiesQuery();
+	const { getHabitsForTimeWindow } = useHabitsData();
 
 	const [currentDate, setCurrentDate] = useState<Dayjs>(() => today());
+	const timeWindow: TimeWindow = useMemo(
+		() => ({
+			startDate: currentDate.startOf("day"),
+			endDate: currentDate.endOf("day"),
+			intervalUnit: "day" // TODO: this needs to change as soon as we want to support other intervals in Today.
+		}),
+		[currentDate]
+	);
 
 	function changeDay(direction: "next" | "previous") {
 		setCurrentDate((current) => current.add(direction === "next" ? 1 : -1, "day"));
@@ -55,6 +67,7 @@ function useToday() {
 	);
 
 	return {
+		habits: getHabitsForTimeWindow(timeWindow),
 		activities: todayActivities,
 		allDayActivities,
 		timestampedActivities,
@@ -107,6 +120,7 @@ export default function Today() {
 					{!!t.allDayActivities.length && (
 						<AllDayActivities activities={t.allDayActivities} />
 					)}
+					{!!t.habits && <Habits habits={t.habits} />}
 					<TimelineRows
 						activities={t.timestampedActivities}
 						currentDate={t.currentDate}

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -1,5 +1,7 @@
+import HabitStyle from "@/components/habits/HabitEntryItem/style/Habit.style";
 import { Tag } from "@/components/TagCard/TagCard.style";
-import { getFontSize } from "@/lib/theme/font";
+import ListStyle from "@/lib/theme/components/List.style";
+import { font, getFontSize } from "@/lib/theme/font";
 import { flex } from "@/lib/theme/snippets/flex";
 import { spacing } from "@/lib/theme/snippets/spacing";
 import styled, { css } from "styled-components";
@@ -138,6 +140,43 @@ const AllDayActivityList = styled.ul`
 	padding-inline: 3rem;
 `;
 
+const Habits = styled.div`
+	/* the Habits component is an ItemList, and each Habit is an Item, so we can
+   tweak the styles if we target those styled components. */
+	${ListStyle.ItemList} {
+		gap: 0.4rem;
+		padding-inline: 3rem;
+
+		* {
+			font-size: ${font.size["0.8"]};
+		}
+
+		${ListStyle.Item} {
+			// TODO: I want to match exactly the spacing of AllDayActivityList
+			box-shadow: 0 0 0.2rem 0 #ccc;
+			outline: 2px solid ${(p) => p.theme.colors.blue.main};
+			background-color: ${(p) => p.theme.colors.blue.main};
+
+			${ListStyle.ItemName} {
+				box-shadow: 0 0 0.3rem 0 #666;
+			}
+
+			${ListStyle.Info}, label {
+				color: white;
+			}
+
+			${HabitStyle.CompletionWrapper} {
+				background-color: #eee;
+				padding: 0.5rem;
+
+				span {
+					color: black;
+				}
+			}
+		}
+	}
+`;
+
 export default {
 	Wrapper,
 	TimelineWrapper,
@@ -149,5 +188,6 @@ export default {
 	Columns,
 	Header,
 	Tags,
-	AllDayActivityList
+	AllDayActivityList,
+	Habits
 };

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -10,7 +10,7 @@ const Wrapper = styled.div``;
 
 const TimelineWrapper = styled.section`
 	${flex.column};
-	gap: 1.5rem;
+	gap: 1rem;
 	${spacing.padding.wide({ size: 1, ratio: 3 })};
 
 	max-width: 100%;
@@ -140,11 +140,12 @@ const AllDayActivityList = styled.ul`
 	padding-inline: 3rem;
 `;
 
+// const Habits = styled.div``;
 const Habits = styled.div`
 	/* the Habits component is an ItemList, and each Habit is an Item, so we can
    tweak the styles if we target those styled components. */
 	${ListStyle.ItemList} {
-		gap: 0.4rem;
+		gap: 0.2rem;
 		padding-inline: 3rem;
 
 		* {
@@ -152,25 +153,38 @@ const Habits = styled.div`
 		}
 
 		${ListStyle.Item} {
-			// TODO: I want to match exactly the spacing of AllDayActivityList
-			box-shadow: 0 0 0.2rem 0 #ccc;
-			outline: 2px solid ${(p) => p.theme.colors.blue.main};
-			background-color: ${(p) => p.theme.colors.blue.main};
+			border-radius: 2px;
+			border: 1px solid white;
+
+			box-shadow:
+				0 0rem 0.3rem 0 #ccc,
+				0 0 0.3rem 0 #ddd;
+			background-color: #eee;
+
+			// TODO: I want this to exactly match the spacing of AllDayActivityList
+			${spacing.padding.wide({ size: 0.3, ratio: 3 })}
 
 			${ListStyle.ItemName} {
-				box-shadow: 0 0 0.3rem 0 #666;
+				box-shadow: 0 0 0.1rem 0 #777;
+				border: 1px solid white;
 			}
 
 			${ListStyle.Info}, label {
-				color: white;
+				/* color: white; */
 			}
 
 			${HabitStyle.CompletionWrapper} {
 				background-color: #eee;
-				padding: 0.5rem;
+				${spacing.padding.wide({ size: 0.1, ratio: 3 })};
+				border-radius: 3px;
 
 				span {
 					color: black;
+				}
+
+				// slider background mantine
+				* {
+					--slider-track-bg: #d5d5d5;
 				}
 			}
 		}

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -140,7 +140,6 @@ const AllDayActivityList = styled.ul`
 	padding-inline: 3rem;
 `;
 
-// const Habits = styled.div``;
 const Habits = styled.div`
 	/* the Habits component is an ItemList, and each Habit is an Item, so we can
    tweak the styles if we target those styled components. */

--- a/client/src/components/habits/HabitEntryItem/Habit.tsx
+++ b/client/src/components/habits/HabitEntryItem/Habit.tsx
@@ -23,7 +23,7 @@ export default function Habit({ habit }: HabitProps) {
 				// also need to do the same to the slider wrapper.. bit hacky, maybe
 				// just trigger modal open on button click instead of the whole item.
 				e.stopPropagation();
-				openDetailedHabitModal(habit.habit_id);
+				// openDetailedHabitModal(habit.habit_id);
 			}}
 		>
 			<L.ItemName>{habit.name}</L.ItemName>

--- a/client/src/components/habits/HabitEntryItem/Habits.tsx
+++ b/client/src/components/habits/HabitEntryItem/Habits.tsx
@@ -2,7 +2,6 @@ import DetailedHabit from "@/components/habits/DetailedHabit/DetailedHabit";
 import Habit from "@/components/habits/HabitEntryItem/Habit";
 import useDetailedHabitModal from "@/components/habits/HabitEntryItem/useDetailedHabitModal";
 import Modal from "@/components/Modal";
-import useHabitsData from "@/lib/hooks/useHabitsData";
 import L from "@/lib/theme/components/List.style";
 import type { HabitWithPossiblySyntheticEntries } from "@/types/server/habit.types";
 import type { ById } from "@/types/server/utility.types";
@@ -12,8 +11,7 @@ type HabitsProps = {
 };
 
 export default function Habits({ habits }: HabitsProps) {
-	const { getHabit } = useHabitsData();
-	const { activeHabitId, shouldShowModal, modalId } = useDetailedHabitModal();
+	const { activeHabit, shouldShowModal, modalId } = useDetailedHabitModal();
 
 	return (
 		<>
@@ -29,7 +27,7 @@ export default function Habits({ habits }: HabitsProps) {
 
 			{shouldShowModal && (
 				<Modal modalId={modalId} initialOpen={false}>
-					<DetailedHabit habit={getHabit({ habit_id: activeHabitId })} />
+					<DetailedHabit habit={activeHabit} />
 				</Modal>
 			)}
 		</>

--- a/client/src/components/habits/HabitEntryItem/synthetic.ts
+++ b/client/src/components/habits/HabitEntryItem/synthetic.ts
@@ -83,7 +83,6 @@ export function withSyntheticHabitEntries(
 				createDate(entry.date).valueOf() >=
 					createDate(timeWindow.startDate).valueOf() &&
 				createDate(entry.date).valueOf() <= createDate(timeWindow.endDate).valueOf();
-			console.log({ shouldBeVisible, entry });
 			return shouldBeVisible;
 		});
 
@@ -93,7 +92,11 @@ export function withSyntheticHabitEntries(
 				const syntheticEntry: SyntheticHabitEntry = makeSyntheticEntry({
 					habit,
 					index,
-					date: createDate(new Date())
+					// TODO: for now, using timeWindow.startDate probably works well
+					// enough, but I think it's still not perfect for the case where
+					// a user adds an entry in retrospect. Maybe we should just
+					// disallow that altogether.
+					date: timeWindow.startDate
 				});
 				index += 1;
 				entries.push(syntheticEntry);

--- a/client/src/components/habits/HabitEntryItem/useDetailedHabitModal.ts
+++ b/client/src/components/habits/HabitEntryItem/useDetailedHabitModal.ts
@@ -3,20 +3,24 @@
 // modals anyway, so they can share the same modal id (I was already using
 // modalIds.detailedActivity for both anyway).
 
+import useHabitsData from "@/lib/hooks/useHabitsData";
 import modalIds from "@/lib/modal-ids";
 import { useModalState } from "@/lib/state/modal-state";
-import type { Habit } from "@/types/server/habit.types";
+import type { Habit, HabitWithEntries } from "@/types/server/habit.types";
 import type { ID } from "@/types/server/utility.types";
+import { useMemo } from "react";
 import { atom, useRecoilState } from "recoil";
 
 type WithActiveHabit = {
 	shouldShowModal: true;
 	activeHabitId: ID;
+	activeHabit: HabitWithEntries;
 };
 
 type WithoutActiveHabit = {
 	shouldShowModal: false;
 	activeHabitId: null;
+	activeHabit: null;
 };
 
 type Return = (WithActiveHabit | WithoutActiveHabit) & {
@@ -33,17 +37,25 @@ export default function useDetailedHabitModal() {
 	const [activeHabitId, setActiveHabitId] = useRecoilState(activeHabitIdState);
 	const { openModal } = useModalState();
 
+	const { habitsWithEntriesById } = useHabitsData();
 	const shouldShowModal = (activeHabitId !== null) as true | false;
-	const modalId = modalIds.detailedActivity;
+	const modalId = modalIds.habits.detailed;
 	function openDetailedHabitModal(id: Habit["habit_id"]) {
 		setActiveHabitId(id);
 		openModal(modalId); // TODO: generalize this as describe at the top of this file
 	}
 
+	const activeHabit = useMemo(() => {
+		if (!activeHabitId) return null;
+
+		return habitsWithEntriesById[activeHabitId];
+	}, [activeHabitId]);
+
 	return {
 		shouldShowModal,
 		modalId,
 		activeHabitId,
+		activeHabit,
 		openDetailedHabitModal
 	} as Return;
 }

--- a/client/src/lib/activity.ts
+++ b/client/src/lib/activity.ts
@@ -227,7 +227,7 @@ function firstOverlappingActivity(
 				const second = activities.find((a) => a.activity_id === otherId);
 				if (!first || !second) continue;
 				if (isSimultaneousActivity(first, second)) {
-					return sortActivitiesByTime([first, second]).at(1); // .at(1) looks better, but .at(0) looks more like intended order
+					return sortActivitiesByTime([first, second]).at(0); // .at(1) looks better, but .at(0) looks more like intended order
 				}
 			}
 		}

--- a/client/src/lib/hooks/useHabitsData.ts
+++ b/client/src/lib/hooks/useHabitsData.ts
@@ -1,7 +1,9 @@
+import { withSyntheticHabitEntries } from "@/components/habits/HabitEntryItem/synthetic";
 import useHabitEntriesQuery from "@/lib/query/habits/useHabitEntriesQuery";
 import useHabitsQuery from "@/lib/query/habits/useHabitsQuery";
 import type { Habit, HabitWithEntries } from "@/types/server/habit.types";
 import type { ById } from "@/types/server/utility.types";
+import type { TimeWindow } from "@/types/time-window.types";
 import { useCallback, useMemo } from "react";
 
 export default function useHabitsData() {
@@ -21,6 +23,13 @@ export default function useHabitsData() {
 		}, {} as ById<HabitWithEntries>);
 	}, [habitsData, habitEntriesData]);
 
+	const getHabitsForTimeWindow = useCallback(
+		(timeWindow: TimeWindow) => {
+			return withSyntheticHabitEntries(habitsWithEntriesById, timeWindow);
+		},
+		[habitsWithEntriesById]
+	);
+
 	const getHabit = useCallback(
 		({ habit_id }: Pick<Habit, "habit_id">) => {
 			return habitsWithEntriesById[habit_id];
@@ -28,5 +37,5 @@ export default function useHabitsData() {
 		[habitsWithEntriesById]
 	);
 
-	return { habitsWithEntriesById, getHabit };
+	return { habitsWithEntriesById, getHabit, getHabitsForTimeWindow };
 }

--- a/client/src/lib/hooks/useHabitsData.ts
+++ b/client/src/lib/hooks/useHabitsData.ts
@@ -25,6 +25,10 @@ export default function useHabitsData() {
 
 	const getHabitsForTimeWindow = useCallback(
 		(timeWindow: TimeWindow) => {
+			// TODO: filter out habits whose start/end date do not fall within
+			// timeWindow.
+			// TODO: (unsure if we should do that here) consider disallowing
+			// interaction with entries once their timeWindow has passed.
 			return withSyntheticHabitEntries(habitsWithEntriesById, timeWindow);
 		},
 		[habitsWithEntriesById]

--- a/client/src/lib/modal-ids.ts
+++ b/client/src/lib/modal-ids.ts
@@ -6,7 +6,8 @@ export default {
 		newHabit: "new-habit-tag-selector"
 	},
 	habits: {
-		new: "new-habit"
+		new: "new-habit",
+		detailed: "detailed-habit"
 	},
 	notes: {
 		home: "home-notes",

--- a/client/src/lib/state/selected-time-window-state.ts
+++ b/client/src/lib/state/selected-time-window-state.ts
@@ -1,0 +1,17 @@
+import { createDate } from "@/lib/datetime/make-date";
+import type { TimeWindow } from "@/types/time-window.types";
+import { atom } from "recoil";
+
+/**
+ * Global state for the selected time window.
+ * @todo this is currently not yet used in the one place where it could be
+ * (Today), but it's here for when we do start needing it.
+ */
+export const selectedTimeWindowState = atom<TimeWindow>({
+	default: {
+		intervalUnit: "day",
+		startDate: createDate(new Date()).startOf("day"),
+		endDate: createDate(new Date()).endOf("day")
+	},
+	key: "selectedTimeWindowState"
+});

--- a/docker/database-setup/14-create-habits.sql
+++ b/docker/database-setup/14-create-habits.sql
@@ -19,7 +19,7 @@ create table if not exists habit_entries (
    habit_id serial not null references habits(habit_id) on delete cascade,
    user_id serial not null references users(user_id),
    created_at timestamp default now(),
-   date date not null,
+   date timestamptz not null,
    index integer not null check(index >= 0),
    value varchar(255) not null
 );


### PR DESCRIPTION
Closes #111.

- (feat) display Habits on Today above all-day activities
- (fix) make `habit_entries.date` a timestamp instead of a date on the database. 
  This was causing issues by parsing dayjs objects that were set to the start of a given date to the previous day's date instead, which was messing up habit entry interactions.
- (dev) disable opening a detailed habit modal on habit click. 
  We'll add a separate button for this, because there's already a bunch of interaction on the card, so it's confusing that clicking a random spot is also a working interaction.
- (fix) use the given time window's start date as the date given to synthetic habit entries. 
  This was causing issues when interacting with habits from days other than today, because the entries would end up on a completion instance for today, rather than the date belonging to the entry the user interacted with.
- (dev) change which one of a pair of overlapping activities gets reshuffled to the front.
  I'm still not sure which one I prefer. It really depends on the specific set of displayed activities which looks better.
- (wip) created a state atom for the selected time window. 
  It's not used yet, but there will be cases soon where it _will_ be, so since I was working on time window stuff anyway, figured I'd add it.