### PR TITLE
use default times in `DateTimePicker` when applicable

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -20,7 +20,7 @@ module.exports = {
 	},
 	plugins: ["react", "@typescript-eslint", "eslint-plugin-react-compiler", "track"],
 	root: true,
-	ignores: ["node_modules", "build", "dist"],
+	ignorePatterns: ["node_modules", "build", "dist"],
 	settings: {
 		react: {
 			version: "detect"

--- a/client/src/components/Today/Activity.tsx
+++ b/client/src/components/Today/Activity.tsx
@@ -1,7 +1,7 @@
 import { useDetailedActivityModal } from "@/components/Today/hooks/useDetailedActivityModal";
 import { activityDurationOnDate, activityStartOnDate } from "@/lib/activity";
 import type { ActivityWithIds } from "@t/data/activity.types";
-import { Datelike } from "@t/data/utility.types";
+import type { Datelike } from "@t/data/utility.types";
 import T from "./style/Activity.style";
 
 function useActivity(activity: ActivityWithIds, date: Datelike) {

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -13,11 +13,11 @@ import useActivitiesQuery from "@/lib/hooks/query/activities/useActivitiesQuery"
 import useHabitsData from "@/lib/hooks/useHabitsData";
 import modalIds from "@/lib/modal-ids";
 import { useModalState } from "@/lib/state/modal-state";
-import type { TimeWindow } from "@/types/time-window.types";
+import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
 import { activityFallsOnDay, isAllDayActivityOnDate } from "@lib/activity";
 import type { Dayjs } from "dayjs";
-import { useMemo, useState } from "react";
-import { useRecoilValue } from "recoil";
+import { useEffect, useMemo, useState } from "react";
+import { useRecoilState, useRecoilValue } from "recoil";
 import Notes from "./Notes";
 import S from "./style/Today.style";
 import Tasks from "./Tasks";
@@ -28,14 +28,17 @@ function useToday() {
 	const { getHabitsForTimeWindow } = useHabitsData();
 
 	const [currentDate, setCurrentDate] = useState<Dayjs>(() => today());
-	const timeWindow: TimeWindow = useMemo(
-		() => ({
-			startDate: currentDate.startOf("day"),
-			endDate: currentDate.endOf("day"),
-			intervalUnit: "day" // TODO: this needs to change as soon as we want to support other intervals in Today.
-		}),
-		[currentDate]
-	);
+	const [timeWindow, setTimeWindow] = useRecoilState(selectedTimeWindowState);
+
+	useEffect(() => {
+		if (currentDate) {
+			setTimeWindow({
+				startDate: currentDate.startOf("day"),
+				endDate: currentDate.endOf("day"),
+				intervalUnit: "day"
+			});
+		}
+	}, [currentDate]);
 
 	function changeDay(direction: "next" | "previous") {
 		setCurrentDate((current) => current.add(direction === "next" ? 1 : -1, "day"));

--- a/client/src/components/activities/NewActivity/DateTimePicker.tsx
+++ b/client/src/components/activities/NewActivity/DateTimePicker.tsx
@@ -11,23 +11,14 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 		manualEndDate,
 		defaultStartDate,
 		date,
-		defaultStartTime,
-		defaultEndTime,
-		onStartDateChange,
-		onEndDateChange,
-		onAllDayChange,
-		onTimeChange
+		defaultTime,
+		onAllDayFieldChange,
+		onStartDateFieldChange,
+		onEndDateFieldChange,
+		onTimeFieldChange
 	} = useDateTimePicker({
 		setState
 	});
-
-	// TODO: defaultStartDate is currently _always_ set to today. Use the
-	// selectedTimeWindow state in Today and also here (through NewActivity? Or
-	// directly here?) to properly determine this. The intended functionality is
-	// that the current time gets suggested if the user is creating an activity
-	// for today, otherwise no time is suggested. Also, if Today is set to a date
-	// other than today, the default dates should be set to that date, instead of
-	// to today.
 
 	return (
 		<S.Form>
@@ -38,13 +29,17 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 						<DefaultInput
 							type="date"
 							defaultValue={defaultStartDate}
-							onChange={onStartDateChange}
+							onChange={onStartDateFieldChange}
 						/>
 					</S.Label>
 
 					<S.Label $faded={!manualEndDate}>
 						<span>End date</span>
-						<DefaultInput type="date" value={date.end} onChange={onEndDateChange} />
+						<DefaultInput
+							type="date"
+							value={date.end}
+							onChange={onEndDateFieldChange}
+						/>
 					</S.Label>
 					<S.Info
 						title={
@@ -61,8 +56,8 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 						<span>Start time</span>
 						<DefaultInput
 							type="text"
-							onBlur={(e) => onTimeChange(e, "start")}
-							defaultValue={defaultStartTime}
+							onBlur={(e) => onTimeFieldChange(e, "start")}
+							defaultValue={defaultTime.start}
 							// TODO: Need something in the UI to clarify the time
 							// format (also in the endTime field), just this
 							// placeholder is not enough -- do this after implementing
@@ -76,15 +71,19 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 						<DefaultInput
 							type="text"
 							placeholder={"HHmm"}
-							onBlur={(e) => onTimeChange(e, "end")}
-							defaultValue={defaultEndTime}
+							onBlur={(e) => onTimeFieldChange(e, "end")}
+							defaultValue={defaultTime.end}
 							disabled={allDay}
 						/>
 					</S.Label>
 				</S.Fields>
 				<S.AllDay>
 					All day?
-					<S.Checkbox type="checkbox" checked={allDay} onChange={onAllDayChange} />
+					<S.Checkbox
+						type="checkbox"
+						checked={allDay}
+						onChange={onAllDayFieldChange}
+					/>
 					<S.Icon>
 						<Checkbox checked={allDay} />
 					</S.Icon>

--- a/client/src/components/activities/NewActivity/DateTimePicker.tsx
+++ b/client/src/components/activities/NewActivity/DateTimePicker.tsx
@@ -11,7 +11,8 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 		manualEndDate,
 		defaultStartDate,
 		date,
-		time,
+		defaultStartTime,
+      defaultEndTime,
 		onStartDateChange,
 		onEndDateChange,
 		onAllDayChange,
@@ -61,7 +62,7 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 						<DefaultInput
 							type="text"
 							onBlur={(e) => onTimeChange(e, "start")}
-							defaultValue={time.start}
+							defaultValue={defaultStartTime}
 							// TODO: Need something in the UI to clarify the time
 							// format (also in the endTime field), just this
 							// placeholder is not enough -- do this after implementing
@@ -76,7 +77,7 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 							type="text"
 							placeholder={"HHmm"}
 							onBlur={(e) => onTimeChange(e, "end")}
-							defaultValue={time.end}
+							defaultValue={defaultEndTime}
 							disabled={allDay}
 						/>
 					</S.Label>

--- a/client/src/components/activities/NewActivity/DateTimePicker.tsx
+++ b/client/src/components/activities/NewActivity/DateTimePicker.tsx
@@ -11,6 +11,7 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 		manualEndDate,
 		defaultStartDate,
 		date,
+		time,
 		onStartDateChange,
 		onEndDateChange,
 		onAllDayChange,
@@ -18,6 +19,14 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 	} = useDateTimePicker({
 		setState
 	});
+
+	// TODO: defaultStartDate is currently _always_ set to today. Use the
+	// selectedTimeWindow state in Today and also here (through NewActivity? Or
+	// directly here?) to properly determine this. The intended functionality is
+	// that the current time gets suggested if the user is creating an activity
+	// for today, otherwise no time is suggested. Also, if Today is set to a date
+	// other than today, the default dates should be set to that date, instead of
+	// to today.
 
 	return (
 		<S.Form>
@@ -52,6 +61,7 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 						<DefaultInput
 							type="text"
 							onBlur={(e) => onTimeChange(e, "start")}
+							defaultValue={time.start}
 							// TODO: Need something in the UI to clarify the time
 							// format (also in the endTime field), just this
 							// placeholder is not enough -- do this after implementing
@@ -66,6 +76,7 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 							type="text"
 							placeholder={"HHmm"}
 							onBlur={(e) => onTimeChange(e, "end")}
+							defaultValue={time.end}
 							disabled={allDay}
 						/>
 					</S.Label>

--- a/client/src/components/activities/NewActivity/DateTimePicker.tsx
+++ b/client/src/components/activities/NewActivity/DateTimePicker.tsx
@@ -12,7 +12,7 @@ export default function DateTimePicker({ setState }: DateTimePickerProps) {
 		defaultStartDate,
 		date,
 		defaultStartTime,
-      defaultEndTime,
+		defaultEndTime,
 		onStartDateChange,
 		onEndDateChange,
 		onAllDayChange,

--- a/client/src/components/activities/NewActivity/useDateTimePicker.ts
+++ b/client/src/components/activities/NewActivity/useDateTimePicker.ts
@@ -98,6 +98,7 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 		setManualEndDate,
 		date,
 		setDate,
+		time,
 		defaultStartDate,
 		onStartDateChange,
 		onEndDateChange,

--- a/client/src/components/activities/NewActivity/useDateTimePicker.ts
+++ b/client/src/components/activities/NewActivity/useDateTimePicker.ts
@@ -1,6 +1,6 @@
 import { isToday } from "@/lib/datetime/compare";
 import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
-import { createDate, today } from "@lib/datetime/make-date";
+import { createDate, now } from "@lib/datetime/make-date";
 import { parseTimeString } from "@lib/datetime/parse-string";
 import { useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
@@ -39,7 +39,7 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 		end: defaultStartDate
 	});
 
-	const currentTime = today();
+	const currentTime = now();
 
 	const [time, setTime] = useState({
 		start: currentTime.format("HHmm"),

--- a/client/src/components/activities/NewActivity/useDateTimePicker.ts
+++ b/client/src/components/activities/NewActivity/useDateTimePicker.ts
@@ -3,34 +3,24 @@ import useCurrentTime from "@/lib/hooks/useCurrentTime";
 import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
 import { createDate } from "@lib/datetime/make-date";
 import { parseTimeString } from "@lib/datetime/parse-string";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
 import type { DateTimePickerProps } from "./datetime-picker.types";
 
 export default function useDateTimePicker({ setState }: DateTimePickerProps) {
+	const currentTime = useCurrentTime(); // the default interval on this might be too short, causing too many re-renders.
+	const timeWindow = useRecoilValue(selectedTimeWindowState);
+	const [manualEndDate, setManualEndDate] = useState(false);
 	const [allDay, setAllDay] = useState(false);
 
-	// When allDay changes, we have to clear out the values, because we don't
-	// want to end up with a situation where start_date AND started_at are
-	// both set to some value. Would rather only have one field present at a time
-	// to prevent issues.
-	useEffect(() => {
-		const unusedStartField = allDay ? "started_at" : "start_date";
-		const unusedEndField = allDay ? "ended_at" : "end_date";
-
-		setState({ name: unusedStartField, value: "" });
-		setState({ name: unusedEndField, value: "" });
+	const dateFields = useMemo(() => {
+		const start = allDay ? "start_date" : "started_at";
+		const end = allDay ? "end_date" : "ended_at";
+		const unusedStart = allDay ? "started_at" : "start_date";
+		const unusedEnd = allDay ? "ended_at" : "end_date";
+		return { start, end, unusedStart, unusedEnd } as const;
 	}, [allDay]);
 
-	const { startField, endField } = useMemo(() => {
-		return {
-			startField: allDay ? "start_date" : "started_at",
-			endField: allDay ? "end_date" : "ended_at"
-		} as const;
-	}, [allDay]);
-
-	const [manualEndDate, setManualEndDate] = useState(false);
-	const timeWindow = useRecoilValue(selectedTimeWindowState);
 	const defaultStartDate = useMemo(() => {
 		return timeWindow.startDate.format("YYYY-MM-DD");
 	}, [timeWindow.startDate]);
@@ -40,33 +30,39 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 		end: defaultStartDate
 	});
 
-	const currentTime = useCurrentTime(); // the default interval on this might be too short, causing too many re-renders.
-
 	const [time, setTime] = useState({
 		start: currentTime.format("HHmm"),
 		end: currentTime.add(1, "hour").format("HHmm")
 	});
 
-	const defaultTime = useMemo(() => {
-		return isToday(timeWindow.startDate) ? currentTime.format("HHmm") : null;
-	}, [timeWindow.startDate, currentTime]);
+	const defaultTime = useMemo(
+		() => ({
+			start: isToday(timeWindow.startDate) ? currentTime.format("HHmm") : "",
+			end: isToday(timeWindow.startDate)
+				? currentTime.add(1, "hour").format("HHmm")
+				: ""
+		}),
+		[timeWindow.startDate, currentTime]
+	);
 
-	const defaultStartTime = defaultTime ? defaultTime : "";
-	const defaultEndTime = defaultTime ? currentTime.add(1, "hour").format("HHmm") : "";
+	const dateTime = useMemo(
+		() => ({
+			start: createDate(allDay ? date.start : `${date.start}T${time.start}`),
+			end: createDate(allDay ? date.end : `${date.end}T${time.end}`)
+		}),
+		[date, time, allDay]
+	);
 
-	const dateTime = useMemo(() => {
-		const [start, end] = [
-			createDate(allDay ? date.start : `${date.start}T${time.start}`),
-			createDate(allDay ? date.end : `${date.end}T${time.end}`)
-		];
-
-		return { start, end };
-	}, [date, time, allDay]);
+	// Clear out unused fields when allDay is toggled
+	useEffect(() => {
+		setState({ name: dateFields.unusedStart, value: "" });
+		setState({ name: dateFields.unusedEnd, value: "" });
+	}, [allDay]);
 
 	useEffect(() => {
-		setState({ name: startField, value: dateTime.start });
-		setState({ name: endField, value: dateTime.end });
-	}, [startField, endField, dateTime]);
+		setState({ name: dateFields.start, value: dateTime.start });
+		setState({ name: dateFields.end, value: dateTime.end });
+	}, [dateFields, dateTime]);
 
 	function handleDateChange(value: string, field: "start" | "end") {
 		setDate((current) => ({
@@ -75,14 +71,14 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 		}));
 	}
 
-	function onStartDateChange(e: React.ChangeEvent<HTMLInputElement>) {
+	function onStartDateFieldChange(e: React.ChangeEvent<HTMLInputElement>) {
 		handleDateChange(e.target.value, "start");
 		if (!manualEndDate) {
 			handleDateChange(e.target.value, "end");
 		}
 	}
 
-	function onEndDateChange(e: React.ChangeEvent<HTMLInputElement>) {
+	function onEndDateFieldChange(e: React.ChangeEvent<HTMLInputElement>) {
 		if (e.target.value) {
 			handleDateChange(e.target.value, "end");
 			setManualEndDate(true);
@@ -93,32 +89,41 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 		}
 	}
 
-	function onAllDayChange(e: React.ChangeEvent<HTMLInputElement>) {
-		setAllDay(e.target.checked);
-	}
+	const onAllDayFieldChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			setAllDay(e.target.checked);
+			setState({ name: dateFields.start, value: dateTime.start });
+			setState({ name: dateFields.end, value: dateTime.end });
+			setState({ name: dateFields.unusedStart, value: "" });
+			setState({ name: dateFields.unusedEnd, value: "" });
+		},
+		[setState, dateTime, dateFields]
+	);
 
-	function onTimeChange(e: React.ChangeEvent<HTMLInputElement>, field: "start" | "end") {
+	function onTimeFieldChange(
+		e: React.ChangeEvent<HTMLInputElement>,
+		field: "start" | "end"
+	) {
 		if (e.target.value.length !== 4) return; // TODO: this is very temporary
 
-		setTime({
-			...time,
+		setTime((current) => ({
+			...current,
 			[field]: parseTimeString(e.target.value)
-		});
+		}));
 	}
 
 	return {
+		defaultStartDate,
+		defaultTime,
 		allDay,
 		setAllDay,
 		manualEndDate,
 		setManualEndDate,
 		date,
 		setDate,
-		defaultStartDate,
-		onStartDateChange,
-		onEndDateChange,
-		onAllDayChange,
-		onTimeChange,
-		defaultStartTime,
-		defaultEndTime
+		onStartDateFieldChange,
+		onEndDateFieldChange,
+		onAllDayFieldChange,
+		onTimeFieldChange
 	};
 }

--- a/client/src/components/activities/NewActivity/useDateTimePicker.ts
+++ b/client/src/components/activities/NewActivity/useDateTimePicker.ts
@@ -1,6 +1,7 @@
 import { isToday } from "@/lib/datetime/compare";
+import useCurrentTime from "@/lib/hooks/useCurrentTime";
 import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
-import { createDate, now } from "@lib/datetime/make-date";
+import { createDate } from "@lib/datetime/make-date";
 import { parseTimeString } from "@lib/datetime/parse-string";
 import { useEffect, useMemo, useState } from "react";
 import { useRecoilValue } from "recoil";
@@ -39,7 +40,7 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 		end: defaultStartDate
 	});
 
-	const currentTime = now();
+	const currentTime = useCurrentTime(); // the default interval on this might be too short, causing too many re-renders.
 
 	const [time, setTime] = useState({
 		start: currentTime.format("HHmm"),

--- a/client/src/components/activities/NewActivity/useDateTimePicker.ts
+++ b/client/src/components/activities/NewActivity/useDateTimePicker.ts
@@ -1,6 +1,9 @@
+import { isToday } from "@/lib/datetime/compare";
+import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
 import { createDate, today } from "@lib/datetime/make-date";
 import { parseTimeString } from "@lib/datetime/parse-string";
 import { useEffect, useMemo, useState } from "react";
+import { useRecoilValue } from "recoil";
 import type { DateTimePickerProps } from "./datetime-picker.types";
 
 export default function useDateTimePicker({ setState }: DateTimePickerProps) {
@@ -26,7 +29,10 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 	}, [allDay]);
 
 	const [manualEndDate, setManualEndDate] = useState(false);
-	const defaultStartDate = today().format("YYYY-MM-DD");
+	const timeWindow = useRecoilValue(selectedTimeWindowState);
+	const defaultStartDate = useMemo(() => {
+		return timeWindow.startDate.format("YYYY-MM-DD");
+	}, [timeWindow.startDate]);
 
 	const [date, setDate] = useState({
 		start: defaultStartDate,
@@ -34,10 +40,18 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 	});
 
 	const currentTime = today();
+
 	const [time, setTime] = useState({
 		start: currentTime.format("HHmm"),
 		end: currentTime.add(1, "hour").format("HHmm")
 	});
+
+	const defaultTime = useMemo(() => {
+		return isToday(timeWindow.startDate) ? currentTime.format("HHmm") : null;
+	}, [timeWindow.startDate, currentTime]);
+
+	const defaultStartTime = defaultTime ? defaultTime : "";
+	const defaultEndTime = defaultTime ? currentTime.add(1, "hour").format("HHmm") : "";
 
 	const dateTime = useMemo(() => {
 		const [start, end] = [
@@ -98,11 +112,12 @@ export default function useDateTimePicker({ setState }: DateTimePickerProps) {
 		setManualEndDate,
 		date,
 		setDate,
-		time,
 		defaultStartDate,
 		onStartDateChange,
 		onEndDateChange,
 		onAllDayChange,
-		onTimeChange
+		onTimeChange,
+		defaultStartTime,
+		defaultEndTime
 	};
 }

--- a/client/src/lib/state/selected-time-window-state.ts
+++ b/client/src/lib/state/selected-time-window-state.ts
@@ -1,4 +1,4 @@
-import { createDate } from "@/lib/datetime/make-date";
+import { now } from "@/lib/datetime/make-date";
 import type { TimeWindow } from "@/types/time-window.types";
 import { atom } from "recoil";
 
@@ -10,8 +10,8 @@ import { atom } from "recoil";
 export const selectedTimeWindowState = atom<TimeWindow>({
 	default: {
 		intervalUnit: "day",
-		startDate: createDate(new Date()).startOf("day"),
-		endDate: createDate(new Date()).endOf("day")
+		startDate: now().startOf("day"),
+		endDate: now().endOf("day")
 	},
 	key: "selectedTimeWindowState"
 });

--- a/client/src/types/time-window.types.ts
+++ b/client/src/types/time-window.types.ts
@@ -1,4 +1,4 @@
-import { Dayjs } from "dayjs";
+import type { Dayjs } from "dayjs";
 
 export type TimeWindow = {
 	intervalUnit: "day" | "week" | "month" | "year"; // TODO: name this "interval_unit"? also add an interval field

--- a/client/src/types/time-window.types.ts
+++ b/client/src/types/time-window.types.ts
@@ -1,7 +1,7 @@
-import type { Datelike } from "@t/data/utility.types";
+import { Dayjs } from "dayjs";
 
 export type TimeWindow = {
 	intervalUnit: "day" | "week" | "month" | "year"; // TODO: name this "interval_unit"? also add an interval field
-	startDate: Datelike;
-	endDate: Datelike;
+	startDate: Dayjs;
+	endDate: Dayjs;
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,7 +16,7 @@ async function start() {
 		cors({
 			origin: true, // Could also use client domain (in dev: http://localhost:3000)
 			credentials: true,
-		})
+		}),
 	);
 
 	app.use(logRequests);
@@ -26,7 +26,7 @@ async function start() {
 			limit: "5mb",
 			parameterLimit: 10000,
 			extended: true,
-		}) as RequestHandler
+		}) as RequestHandler,
 	);
 
 	app.use(express.json() as RequestHandler);

--- a/server/src/lib/data/request-handlers/delete/delete-habit.ts
+++ b/server/src/lib/data/request-handlers/delete/delete-habit.ts
@@ -1,5 +1,5 @@
 import { deleteHabitById } from "@/lib/data/delete-habit";
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 const deleteHabit: RequestHandler = async (req, res) => {
 	const { habit_id } = req.params;

--- a/server/src/lib/data/request-handlers/get/get-activities.ts
+++ b/server/src/lib/data/request-handlers/get/get-activities.ts
@@ -1,5 +1,5 @@
 import { queryActivitiesAndRelations } from "@/lib/data/query-activities";
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 const getActivities: RequestHandler = async (req, res) => {
 	const user_id = req.session.user!.user_id;

--- a/server/src/lib/data/request-handlers/get/get-habit-entries.ts
+++ b/server/src/lib/data/request-handlers/get/get-habit-entries.ts
@@ -1,5 +1,5 @@
 import { groupById, queryHabitEntriesByUser } from "@/lib/data/query-habit-entries";
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 const getHabitEntries: RequestHandler = async (req, res) => {
 	const user_id = req.session.user!.user_id;

--- a/server/src/lib/data/request-handlers/get/get-habits.ts
+++ b/server/src/lib/data/request-handlers/get/get-habits.ts
@@ -1,5 +1,5 @@
 import { queryHabitsAndRelations } from "@/lib/data/query-habits";
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 const getHabits: RequestHandler = async (req, res) => {
 	const user_id = req.session.user!.user_id; // always exists if we're here, because of middleware

--- a/server/src/lib/data/request-handlers/get/get-notes.ts
+++ b/server/src/lib/data/request-handlers/get/get-notes.ts
@@ -1,5 +1,5 @@
 import { queryNotesAndRelations } from "@/lib/data/query-notes";
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 const getNotes: RequestHandler = async (req, res) => {
 	const user_id = req.session.user!.user_id; // always exists if we're here, because of middleware

--- a/server/src/lib/data/request-handlers/get/get-tags-tree.ts
+++ b/server/src/lib/data/request-handlers/get/get-tags-tree.ts
@@ -2,7 +2,7 @@ import {
 	createTagTreeMap,
 	getTagsWithRelations,
 } from "@/lib/data/merge-tags-and-relations";
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 const getTagsTree: RequestHandler = async (req, res) => {
 	const user_id = req.session.user!.user_id; // always exists if we're here, because of middleware

--- a/server/src/lib/data/request-handlers/get/get-tags.ts
+++ b/server/src/lib/data/request-handlers/get/get-tags.ts
@@ -1,5 +1,5 @@
 import { getTagsWithRelations } from "@/lib/data/merge-tags-and-relations";
-import { RequestHandler } from "express";
+import type { RequestHandler } from "express";
 
 const getTags: RequestHandler = async (req, res) => {
 	const user_id = req.session.user!.user_id; // always exists if we're here, because of middleware

--- a/server/src/lib/data/request-handlers/post/post-activity.ts
+++ b/server/src/lib/data/request-handlers/post/post-activity.ts
@@ -1,6 +1,6 @@
 import { insertActivityWithTags } from "@/lib/data/insert-activity";
-import { ActivityInput } from "@t/data/activity.types";
-import { RequestHandler } from "express";
+import type { ActivityInput } from "@t/data/activity.types";
+import type { RequestHandler } from "express";
 
 const postActivity: RequestHandler = async (req, res) => {
 	const { activity, tagIds } = req.body as ActivityInput;

--- a/server/src/lib/data/request-handlers/post/post-habit-entry.ts
+++ b/server/src/lib/data/request-handlers/post/post-habit-entry.ts
@@ -1,6 +1,6 @@
 import { insertHabitEntry } from "@/lib/data/insert-habit-entry";
-import { HabitEntryInput } from "@t/data/habit.types";
-import { RequestHandler } from "express";
+import type { HabitEntryInput } from "@t/data/habit.types";
+import type { RequestHandler } from "express";
 
 const postHabitEntry: RequestHandler = async (req, res) => {
 	const { habitEntry } = req.body as HabitEntryInput;

--- a/server/src/lib/data/request-handlers/post/post-habit.ts
+++ b/server/src/lib/data/request-handlers/post/post-habit.ts
@@ -1,6 +1,6 @@
 import { insertHabitWithTags } from "@/lib/data/insert-habit";
-import { HabitInput } from "@t/data/habit.types";
-import { RequestHandler } from "express";
+import type { HabitInput } from "@t/data/habit.types";
+import type { RequestHandler } from "express";
 
 const postHabit: RequestHandler = async (req, res) => {
 	const { habit, tagIds } = req.body as HabitInput;

--- a/server/src/lib/data/request-handlers/post/post-note.ts
+++ b/server/src/lib/data/request-handlers/post/post-note.ts
@@ -1,6 +1,6 @@
 import { insertNoteWithTags } from "@/lib/data/insert-note";
-import { NoteInput } from "@t/data/note.types";
-import { RequestHandler } from "express";
+import type { NoteInput } from "@t/data/note.types";
+import type { RequestHandler } from "express";
 
 const postNote: RequestHandler = async (req, res) => {
 	const { note, tagIds } = req.body as NoteInput;

--- a/server/src/lib/data/request-handlers/post/post-tag.ts
+++ b/server/src/lib/data/request-handlers/post/post-tag.ts
@@ -1,6 +1,6 @@
 import { insertTagWithRelation } from "@/lib/data/insert-tags";
-import { TagInput } from "@t/data/tag.types";
-import { RequestHandler } from "express";
+import type { TagInput } from "@t/data/tag.types";
+import type { RequestHandler } from "express";
 
 const postTag: RequestHandler = async (req, res) => {
 	const { newTag, parent_id } = req.body as TagInput;

--- a/server/src/lib/data/request-handlers/put/put-task.ts
+++ b/server/src/lib/data/request-handlers/put/put-task.ts
@@ -1,7 +1,7 @@
 import { queryActivityByIdWithRelations } from "@/lib/data/query-activities";
 import { updateActivityCompletion } from "@/lib/data/update-activity";
-import { ActivityUpdateInput } from "@t/data/activity.types";
-import { RequestHandler } from "express";
+import type { ActivityUpdateInput } from "@t/data/activity.types";
+import type { RequestHandler } from "express";
 
 const putTaskCompletion: RequestHandler = async (req, res) => {
 	const { input } = req.body as { input: ActivityUpdateInput };

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -15,7 +15,6 @@
 		"baseUrl": "../",
 		"rootDir": "../",
 		"types": ["jest", "node"],
-		"typeRoots": ["./types", "./node_modules/@types"],
 		"noImplicitAny": true,
 		"paths": {
 			"@/*": ["server/src/*"],


### PR DESCRIPTION
closes #61.

To make this happen, I made `useToday()` use the selected time window state I prepared in advance, because I knew we were going to need it soon.

Also found out my eslint config was wrong, was using `ignores` which apparently is only for eslint v9.x. After fixing it, I ran eslint --fix to make the now-once-again-working linter happy again.

Also fixed server/tsconfig, where typeRoots was preventing tsc from building. Why this only happened when I switched to another machine, I have no clue.