### PR TITLE
"create" button (speed dial)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
 		"build-types": "tsc --build --verbose"
 	},
 	"dependencies": {
+		"@floating-ui/react": "0.26.28",
 		"@mantine/core": "^7.13.4",
 		"@mantine/dates": "^7.13.4",
 		"@mantine/hooks": "^7.13.4",

--- a/client/src/components/Today/Notes.tsx
+++ b/client/src/components/Today/Notes.tsx
@@ -29,16 +29,11 @@ export default function Notes() {
 			{notes.map((n) => (
 				<Note key={n.note_id} note={n} tags={filterTagsById(n.tag_ids, tags?.byId)} />
 			))}
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					openModal(modalIds.notes.new);
-				}}
-			>
-				New note
-			</button>
 
+			{/* TODO: now that we trigger NewNote from the SpeedDial in Today.tsx, 
+         does this modal also have to move to there? Otherwise we can end up with 
+         a state where the modal doesn't open because it's not on the page. Same 
+         goes for the other speed dial actions.*/}
 			<Modal initialOpen={false} modalId={modalIds.notes.new}>
 				<NewNote />
 			</Modal>

--- a/client/src/components/Today/Notes.tsx
+++ b/client/src/components/Today/Notes.tsx
@@ -1,11 +1,7 @@
-import NewNote from "@/components/notes/NewNote/NewNote";
 import Empty from "@/components/Today/Empty";
-import Modal from "@/components/utility/Modal/Modal";
 import { filterTagsById } from "@/lib/filter-tags";
 import useNotesQuery from "@/lib/hooks/query/notes/useNotesQuery";
 import useTagsQuery from "@/lib/hooks/query/tags/useTagsQuery";
-import modalIds from "@/lib/modal-ids";
-import { useModalState } from "@/lib/state/modal-state";
 import { isToday } from "@lib/datetime/compare";
 import { Note } from "./Note";
 import S from "./style/Today.style";
@@ -13,7 +9,6 @@ import S from "./style/Today.style";
 export default function Notes() {
 	const { data: notesData } = useNotesQuery();
 	const { data: tags } = useTagsQuery();
-	const { openModal } = useModalState();
 
 	const notes = Object.values(notesData?.byId ?? {}).filter((note) =>
 		// TODO: note.date is not a field in the client when creating a new note,
@@ -29,14 +24,6 @@ export default function Notes() {
 			{notes.map((n) => (
 				<Note key={n.note_id} note={n} tags={filterTagsById(n.tag_ids, tags?.byId)} />
 			))}
-
-			{/* TODO: now that we trigger NewNote from the SpeedDial in Today.tsx, 
-         does this modal also have to move to there? Otherwise we can end up with 
-         a state where the modal doesn't open because it's not on the page. Same 
-         goes for the other speed dial actions.*/}
-			<Modal initialOpen={false} modalId={modalIds.notes.new}>
-				<NewNote />
-			</Modal>
 		</S.NotesWrapper>
 	);
 }

--- a/client/src/components/Today/Tasks.tsx
+++ b/client/src/components/Today/Tasks.tsx
@@ -4,7 +4,6 @@ import Modal from "@/components/utility/Modal/Modal";
 import { filterTagsById } from "@/lib/filter-tags";
 import useTagsQuery from "@/lib/hooks/query/tags/useTagsQuery";
 import modalIds from "@/lib/modal-ids";
-import { useModalState } from "@/lib/state/modal-state";
 import type { ActivityWithIds } from "@t/data/activity.types";
 import Task from "./Task";
 import T from "./style/Tasks.style";
@@ -16,7 +15,6 @@ type TasksProps = {
 
 export default function Tasks({ activities }: TasksProps) {
 	const { data: tags } = useTagsQuery();
-	const { openModal } = useModalState();
 	const modalId = modalIds.activities.newTask;
 
 	return (
@@ -35,16 +33,8 @@ export default function Tasks({ activities }: TasksProps) {
 			) : (
 				<Empty>No tasks found for today.</Empty>
 			)}
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					openModal(modalId);
-				}}
-			>
-				New task
-			</button>
 
+			{/* TODO: see note from Notes.tsx on whether this modal should still be here. */}
 			<Modal initialOpen={false} modalId={modalId}>
 				<ActivityForm isTask modalId={modalId} />
 			</Modal>

--- a/client/src/components/Today/Tasks.tsx
+++ b/client/src/components/Today/Tasks.tsx
@@ -1,9 +1,6 @@
 import Empty from "@/components/Today/Empty";
-import ActivityForm from "@/components/activities/ActivityForm/ActivityForm";
-import Modal from "@/components/utility/Modal/Modal";
 import { filterTagsById } from "@/lib/filter-tags";
 import useTagsQuery from "@/lib/hooks/query/tags/useTagsQuery";
-import modalIds from "@/lib/modal-ids";
 import type { ActivityWithIds } from "@t/data/activity.types";
 import Task from "./Task";
 import T from "./style/Tasks.style";
@@ -15,7 +12,6 @@ type TasksProps = {
 
 export default function Tasks({ activities }: TasksProps) {
 	const { data: tags } = useTagsQuery();
-	const modalId = modalIds.activities.newTask;
 
 	return (
 		<T.TasksWrapper>
@@ -33,11 +29,6 @@ export default function Tasks({ activities }: TasksProps) {
 			) : (
 				<Empty>No tasks found for today.</Empty>
 			)}
-
-			{/* TODO: see note from Notes.tsx on whether this modal should still be here. */}
-			<Modal initialOpen={false} modalId={modalId}>
-				<ActivityForm isTask modalId={modalId} />
-			</Modal>
 		</T.TasksWrapper>
 	);
 }

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -6,6 +6,7 @@ import ChangeDayButton from "@/components/Today/ChangeDayButton";
 import TimelineRows from "@/components/Today/TimelineRows";
 import Calendar from "@/components/utility/Calendar/Calendar";
 import Modal from "@/components/utility/Modal/Modal";
+import SpeedDial from "@/components/utility/SpeedDial/SpeedDial";
 import { today } from "@/lib/datetime/make-date";
 import useActivitiesQuery from "@/lib/hooks/query/activities/useActivitiesQuery";
 import useHabitsData from "@/lib/hooks/useHabitsData";
@@ -75,24 +76,72 @@ export default function Today() {
 	const t = useToday();
 	const { openModal } = useModalState();
 
+	const [open, setOpen] = useState(false);
+
 	return (
 		<S.Wrapper>
 			{/* TODO: we want the header to be aligned above the Timeline */}
 			<S.Columns>
 				<div>
 					<Calendar initialDate={t.currentDate} onChange={t.setCurrentDate} />
-					<button
+
+					<div
 						style={{
-							marginTop: "1rem"
-						}}
-						type="button"
-						onClick={(e) => {
-							e.stopPropagation();
-							openModal(modalIds.habits.new);
+							position: "fixed",
+							bottom: "10rem",
+							right: "10rem",
+							zIndex: 100
 						}}
 					>
-						New habit
-					</button>
+						<SpeedDial open={open} setOpen={setOpen}>
+							<div
+								style={{
+									display: "flex",
+									flexDirection: "column",
+									gap: "0.5rem",
+									justifyContent: "center",
+									padding: "0 1rem",
+									borderRadius: "3px",
+									alignItems: "center",
+									boxShadow: "0 0.2rem 1.5rem 0 #bbb",
+									fontSize: "0.8rem"
+								}}
+							>
+								<S.SpeedDialButton
+									onClick={(e) => {
+										e.stopPropagation();
+										openModal(modalIds.activities.form);
+									}}
+								>
+									activity
+								</S.SpeedDialButton>
+								<S.SpeedDialButton
+									onClick={(e) => {
+										e.stopPropagation();
+										openModal(modalIds.activities.newTask);
+									}}
+								>
+									task
+								</S.SpeedDialButton>
+								<S.SpeedDialButton
+									onClick={(e) => {
+										e.stopPropagation();
+										openModal(modalIds.habits.new);
+									}}
+								>
+									habit
+								</S.SpeedDialButton>
+								<S.SpeedDialButton
+									onClick={(e) => {
+										e.stopPropagation();
+										openModal(modalIds.notes.new);
+									}}
+								>
+									note
+								</S.SpeedDialButton>
+							</div>
+						</SpeedDial>
+					</div>
 					<Modal initialOpen={false} modalId={modalIds.habits.new}>
 						<NewHabit />
 					</Modal>
@@ -123,17 +172,7 @@ export default function Today() {
 						activities={t.timestampedActivities}
 						currentDate={t.currentDate}
 					/>
-					<div>
-						<button
-							type="button"
-							onClick={(e) => {
-								e.stopPropagation();
-								openModal(modalIds.activities.form);
-							}}
-						>
-							New activity
-						</button>
-					</div>
+					<div></div>
 					<Modal initialOpen={false} modalId={modalIds.activities.form}>
 						<ActivityForm modalId={modalIds.activities.form} />
 					</Modal>

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -62,6 +62,8 @@ function useToday() {
 		`dddd (D MMMM${currentDate.year() !== currentYear ? " YYYY" : ""})`
 	);
 
+	const [speedDialOpen, setSpeedDialOpen] = useState(false);
+
 	return {
 		habits: getHabitsForTimeWindow(timeWindow),
 		activities: todayActivities,
@@ -70,16 +72,16 @@ function useToday() {
 		currentDate,
 		setCurrentDate,
 		title,
-		changeDay
+		changeDay,
+		speedDialOpen,
+		setSpeedDialOpen
 	} as const;
 }
 
 export default function Today() {
 	const t = useToday();
+
 	const { openModal } = useModalState();
-
-	const [open, setOpen] = useState(false);
-
 	function handleModalOpen(e: React.MouseEvent<HTMLButtonElement>, modalId: ModalId) {
 		e.stopPropagation();
 		openModal(modalId);
@@ -93,7 +95,7 @@ export default function Today() {
 					<Calendar initialDate={t.currentDate} onChange={t.setCurrentDate} />
 
 					<S.Create>
-						<SpeedDial open={open} setOpen={setOpen}>
+						<SpeedDial open={t.speedDialOpen} setOpen={t.setSpeedDialOpen}>
 							<S.SpeedDialActions>
 								<S.SpeedDialButton
 									onClick={(e) => handleModalOpen(e, modalIds.activities.form)}

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -1,6 +1,7 @@
 import ActivityForm from "@/components/activities/ActivityForm/ActivityForm";
 import Habits from "@/components/habits/Habits/Habits";
 import NewHabit from "@/components/habits/NewHabit/NewHabit";
+import NewNote from "@/components/notes/NewNote/NewNote";
 import AllDayActivities from "@/components/Today/AllDayActivities";
 import ChangeDayButton from "@/components/Today/ChangeDayButton";
 import TimelineRows from "@/components/Today/TimelineRows";
@@ -119,9 +120,6 @@ export default function Today() {
 							</S.SpeedDialActions>
 						</SpeedDial>
 					</S.Create>
-					<Modal initialOpen={false} modalId={modalIds.habits.new}>
-						<NewHabit />
-					</Modal>
 				</div>
 				<S.TimelineWrapper>
 					<S.Header>
@@ -149,16 +147,28 @@ export default function Today() {
 						activities={t.timestampedActivities}
 						currentDate={t.currentDate}
 					/>
-					<div></div>
-					<Modal initialOpen={false} modalId={modalIds.activities.form}>
-						<ActivityForm modalId={modalIds.activities.form} />
-					</Modal>
 				</S.TimelineWrapper>
 
 				<Tasks activities={t.activities.filter((a) => a.is_task)} />
 
 				<Notes />
 			</S.Columns>
+
+			<Modal initialOpen={false} modalId={modalIds.activities.form}>
+				<ActivityForm modalId={modalIds.activities.form} />
+			</Modal>
+
+			<Modal initialOpen={false} modalId={modalIds.activities.newTask}>
+				<ActivityForm isTask modalId={modalIds.activities.newTask} />
+			</Modal>
+
+			<Modal initialOpen={false} modalId={modalIds.habits.new}>
+				<NewHabit />
+			</Modal>
+
+			<Modal initialOpen={false} modalId={modalIds.notes.new}>
+				<NewNote />
+			</Modal>
 		</S.Wrapper>
 	);
 }

--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -10,6 +10,7 @@ import SpeedDial from "@/components/utility/SpeedDial/SpeedDial";
 import { today } from "@/lib/datetime/make-date";
 import useActivitiesQuery from "@/lib/hooks/query/activities/useActivitiesQuery";
 import useHabitsData from "@/lib/hooks/useHabitsData";
+import type { ModalId } from "@/lib/modal-ids";
 import modalIds from "@/lib/modal-ids";
 import { useModalState } from "@/lib/state/modal-state";
 import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
@@ -78,6 +79,11 @@ export default function Today() {
 
 	const [open, setOpen] = useState(false);
 
+	function handleModalOpen(e: React.MouseEvent<HTMLButtonElement>, modalId: ModalId) {
+		e.stopPropagation();
+		openModal(modalId);
+	}
+
 	return (
 		<S.Wrapper>
 			{/* TODO: we want the header to be aligned above the Timeline */}
@@ -85,63 +91,34 @@ export default function Today() {
 				<div>
 					<Calendar initialDate={t.currentDate} onChange={t.setCurrentDate} />
 
-					<div
-						style={{
-							position: "fixed",
-							bottom: "10rem",
-							right: "10rem",
-							zIndex: 100
-						}}
-					>
+					<S.Create>
 						<SpeedDial open={open} setOpen={setOpen}>
-							<div
-								style={{
-									display: "flex",
-									flexDirection: "column",
-									gap: "0.5rem",
-									justifyContent: "center",
-									padding: "0 1rem",
-									borderRadius: "3px",
-									alignItems: "center",
-									boxShadow: "0 0.2rem 1.5rem 0 #bbb",
-									fontSize: "0.8rem"
-								}}
-							>
+							<S.SpeedDialActions>
 								<S.SpeedDialButton
-									onClick={(e) => {
-										e.stopPropagation();
-										openModal(modalIds.activities.form);
-									}}
+									onClick={(e) => handleModalOpen(e, modalIds.activities.form)}
 								>
 									activity
 								</S.SpeedDialButton>
 								<S.SpeedDialButton
-									onClick={(e) => {
-										e.stopPropagation();
-										openModal(modalIds.activities.newTask);
-									}}
+									onClick={(e) =>
+										handleModalOpen(e, modalIds.activities.newTask)
+									}
 								>
 									task
 								</S.SpeedDialButton>
 								<S.SpeedDialButton
-									onClick={(e) => {
-										e.stopPropagation();
-										openModal(modalIds.habits.new);
-									}}
+									onClick={(e) => handleModalOpen(e, modalIds.habits.new)}
 								>
 									habit
 								</S.SpeedDialButton>
 								<S.SpeedDialButton
-									onClick={(e) => {
-										e.stopPropagation();
-										openModal(modalIds.notes.new);
-									}}
+									onClick={(e) => handleModalOpen(e, modalIds.notes.new)}
 								>
 									note
 								</S.SpeedDialButton>
-							</div>
+							</S.SpeedDialActions>
 						</SpeedDial>
-					</div>
+					</S.Create>
 					<Modal initialOpen={false} modalId={modalIds.habits.new}>
 						<NewHabit />
 					</Modal>

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -1,5 +1,6 @@
 import HabitStyle from "@/components/habits/Habits/style/Habit.style";
 import TagCardStyle from "@/components/tags/TagCard/style/TagCard.style";
+import ButtonStyle from "@/lib/theme/components/Button.style";
 import ListStyle from "@/lib/theme/components/List.style";
 import { font, getFontSize } from "@/lib/theme/font";
 import { flex } from "@/lib/theme/snippets/flex";
@@ -190,6 +191,11 @@ const Habits = styled.div`
 	}
 `;
 
+const SpeedDialButton = styled(ButtonStyle.Create)`
+	width: calc(100% + 2rem);
+	border-radius: 5px;
+`;
+
 export default {
 	Wrapper,
 	TimelineWrapper,
@@ -202,5 +208,6 @@ export default {
 	Header,
 	Tags,
 	AllDayActivityList,
-	Habits
+	Habits,
+	SpeedDialButton
 };

--- a/client/src/components/Today/style/Today.style.ts
+++ b/client/src/components/Today/style/Today.style.ts
@@ -191,6 +191,24 @@ const Habits = styled.div`
 	}
 `;
 
+const Create = styled.div`
+	position: fixed;
+	bottom: 10rem;
+	right: 10rem;
+	z-index: 100;
+`;
+
+const SpeedDialActions = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	justify-content: center;
+	padding: 0 1rem;
+	border-radius: 3px;
+	align-items: center;
+	font-size: 0.8rem;
+`;
+
 const SpeedDialButton = styled(ButtonStyle.Create)`
 	width: calc(100% + 2rem);
 	border-radius: 5px;
@@ -209,5 +227,7 @@ export default {
 	Tags,
 	AllDayActivityList,
 	Habits,
+	Create,
+	SpeedDialActions,
 	SpeedDialButton
 };

--- a/client/src/components/activities/ActivityForm/useActivityForm.ts
+++ b/client/src/components/activities/ActivityForm/useActivityForm.ts
@@ -145,15 +145,15 @@ export default function useActivityForm({
 		}));
 	};
 
-	const title = activity ? "Edit activity" : "Create an activity";
-	const buttonTitle = activity ? "Update activity" : "Create activity";
+	const title = existingActivity ? "Edit activity" : "Create an activity";
+	const buttonTitle = existingActivity ? "Update activity" : "Create activity";
 
-	const defaultDateTimeValues = activity
+	const defaultDateTimeValues = existingActivity
 		? ({
-				started_at: activity.started_at,
-				ended_at: activity.ended_at,
-				start_date: activity.start_date,
-				end_date: activity.end_date
+				started_at: existingActivity.started_at,
+				ended_at: existingActivity.ended_at,
+				start_date: existingActivity.start_date,
+				end_date: existingActivity.end_date
 			} as WithDates | WithTimestamps)
 		: undefined;
 

--- a/client/src/components/utility/SpeedDial/SpeedDial.tsx
+++ b/client/src/components/utility/SpeedDial/SpeedDial.tsx
@@ -1,0 +1,72 @@
+import Button from "@/lib/theme/components/Button.style";
+import {
+	flip,
+	FloatingFocusManager,
+	offset,
+	shift,
+	useClick,
+	useDismiss,
+	useFloating,
+	useInteractions,
+	useRole
+} from "@floating-ui/react";
+import { Plus } from "lucide-react";
+import type { PropsWithChildren } from "react";
+
+type SpeedDialProps = {
+	open: boolean;
+	setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+/** A speed dial is a button that triggers a floating action list, like a list
+ * of action buttons, or a list of shortcuts. */
+export default function SpeedDial({
+	children,
+	open,
+	setOpen
+}: PropsWithChildren<SpeedDialProps>) {
+	const { refs, context, floatingStyles } = useFloating({
+		placement: "top",
+		middleware: [offset(10), flip(), shift()], // I just took this from an example in the docs
+		open,
+		onOpenChange: setOpen
+	});
+
+	const click = useClick(context);
+	const dismiss = useDismiss(context);
+	const role = useRole(context);
+
+	const { getReferenceProps, getFloatingProps } = useInteractions([
+		click,
+		dismiss,
+		role
+	]);
+
+	return (
+		<div
+			ref={refs.setReference}
+			{...getReferenceProps()}
+			style={{
+				position: "relative",
+				width: "max-content"
+			}}
+		>
+			<Button.Create $size={"50px"}>
+				<Plus strokeWidth={3} />
+			</Button.Create>
+			{open && (
+				<div>
+					<FloatingFocusManager context={context} modal={false} disabled>
+						<div
+							ref={refs.setFloating}
+							style={{ ...floatingStyles }}
+							{...getFloatingProps()}
+						>
+							{children}
+						</div>
+					</FloatingFocusManager>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/client/src/components/utility/SpeedDial/SpeedDial.tsx
+++ b/client/src/components/utility/SpeedDial/SpeedDial.tsx
@@ -1,4 +1,5 @@
 import Button from "@/lib/theme/components/Button.style";
+import type { UseFloatingOptions } from "@floating-ui/react";
 import {
 	flip,
 	FloatingFocusManager,
@@ -10,26 +11,29 @@ import {
 	useInteractions,
 	useRole
 } from "@floating-ui/react";
-import { Plus } from "lucide-react";
+import { Minus, Plus } from "lucide-react";
 import type { PropsWithChildren } from "react";
+import S from "./style/SpeedDial.style";
 
 type SpeedDialProps = {
 	open: boolean;
 	setOpen: React.Dispatch<React.SetStateAction<boolean>>;
-};
+} & UseFloatingOptions;
 
 /** A speed dial is a button that triggers a floating action list, like a list
  * of action buttons, or a list of shortcuts. */
 export default function SpeedDial({
 	children,
 	open,
-	setOpen
+	setOpen,
+	...floatingOptions
 }: PropsWithChildren<SpeedDialProps>) {
 	const { refs, context, floatingStyles } = useFloating({
 		placement: "top",
 		middleware: [offset(10), flip(), shift()], // I just took this from an example in the docs
 		open,
-		onOpenChange: setOpen
+		onOpenChange: setOpen,
+		...floatingOptions
 	});
 
 	const click = useClick(context);
@@ -43,16 +47,9 @@ export default function SpeedDial({
 	]);
 
 	return (
-		<div
-			ref={refs.setReference}
-			{...getReferenceProps()}
-			style={{
-				position: "relative",
-				width: "max-content"
-			}}
-		>
+		<S.SpeedDialWrapper ref={refs.setReference} {...getReferenceProps()}>
 			<Button.Create $size={"50px"}>
-				<Plus strokeWidth={3} />
+				{open ? <Minus strokeWidth={3} /> : <Plus strokeWidth={3} />}
 			</Button.Create>
 			{open && (
 				<div>
@@ -67,6 +64,6 @@ export default function SpeedDial({
 					</FloatingFocusManager>
 				</div>
 			)}
-		</div>
+		</S.SpeedDialWrapper>
 	);
 }

--- a/client/src/components/utility/SpeedDial/style/SpeedDial.style.ts
+++ b/client/src/components/utility/SpeedDial/style/SpeedDial.style.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const SpeedDialWrapper = styled.div`
+	position: relative;
+	width: max-content;
+`;
+
+export default {
+	SpeedDialWrapper
+};

--- a/client/src/lib/theme/components/Button.style.ts
+++ b/client/src/lib/theme/components/Button.style.ts
@@ -15,6 +15,7 @@ const Edit = styled(Unstyled)<{ $size?: CSS.Properties["width"] }>`
 	align-items: center;
 	justify-content: center;
 	border-radius: 50%;
+	color: white;
 
 	outline: 2px solid ${(p) => p.theme.colors.blue.main};
 	border: 2px solid #eee;
@@ -38,7 +39,16 @@ const Edit = styled(Unstyled)<{ $size?: CSS.Properties["width"] }>`
 	height: ${(p) => p.$size ?? "var(--default-edit-button-size)"};
 `;
 
+/** TODO: I'm calling this Create right now, but it's really just an Action button, so
+ * it'll be renamed soon enough. */
+const Create = styled(Edit)`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+`;
+
 export default {
 	Unstyled,
-	Edit
+	Edit,
+	Create
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "win32"
       ],
       "dependencies": {
+        "@floating-ui/react": "^0.26.28",
         "@mantine/core": "^7.13.4",
         "@mantine/dates": "^7.13.4",
         "@mantine/hooks": "^7.13.4",


### PR DESCRIPTION
Closes #95.

- (deps) install floating-ui as a dependency
- (feat) implement an initial version of a speed dial button. 
  Honestly the logic we need isn't very complex, I just wanted to get acquainted with the library for when we need other floating elements that stay rendered in view.
- (feat) implement a speed dial in Today to trigger activity, habit and note modals
- (fix) use the proper variable (`existingActivity` instead of `activity`) to determine initial `ActivityForm` state.