### PR TITLE
collapse tag tree on first click

### DIFF
--- a/client/src/components/tags/TagTree/TagTree.tsx
+++ b/client/src/components/tags/TagTree/TagTree.tsx
@@ -89,7 +89,10 @@ function Tag({ tag, level }: TagProps) {
 					<>
 						<S.DropdownCheckbox
 							type="checkbox"
-							onChange={(e) => setCollapsed(e.target.checked)}
+							onChange={(e) => {
+								e.stopPropagation();
+								setCollapsed(e.target.checked);
+							}}
 						/>
 						{collapsed ? (
 							<MdOutlineExpandMore size={18} />

--- a/client/src/components/utility/Modal/Modal.tsx
+++ b/client/src/components/utility/Modal/Modal.tsx
@@ -36,6 +36,7 @@ export default function Modal({
 					handleModalClose(e);
 				}
 			}}
+			data-modal-id={modalId}
 		>
 			<S.Modal ref={modalRef} data-modal-id={modalId}>
 				<S.Close onClick={handleModalClose} />

--- a/client/src/lib/hooks/useClickOutside.ts
+++ b/client/src/lib/hooks/useClickOutside.ts
@@ -1,3 +1,4 @@
+import { findNearestParentModal } from "@/lib/nearest-modal";
 import type { RefObject } from "react";
 import { useEffect, useState } from "react";
 
@@ -19,15 +20,23 @@ export default function useClickOutside<T extends HTMLElement>(
 				return;
 			}
 
+			// If the click is inside a modal, but not inside the modal that this
+			// hook is attached to, don't trigger the handler.
+			const nearestModalId = findNearestParentModal(e.target as Node);
+			const parentModalId = findNearestParentModal(ref.current as Node);
+			if (nearestModalId !== parentModalId) {
+				return;
+			}
+
 			e.preventDefault();
 			e.stopPropagation();
 			handler?.(e);
 			setIsOpen(false);
 		}
 
-		window.addEventListener("click", onClick);
+		document.addEventListener("mousedown", onClick);
 
-		return () => window.removeEventListener("click", onClick);
+		return () => document.removeEventListener("mousedown", onClick);
 	}, [ref, handler, setIsOpen]);
 
 	return { isOpen, setIsOpen };

--- a/client/src/lib/nearest-modal.ts
+++ b/client/src/lib/nearest-modal.ts
@@ -1,0 +1,10 @@
+export function findNearestParentModal(node: Node) {
+	let currentNode: Node | null = node;
+	while (currentNode) {
+		if (currentNode instanceof HTMLElement && currentNode.dataset.modalId) {
+			return currentNode.dataset.modalId;
+		}
+		currentNode = currentNode.parentNode;
+	}
+	return null;
+}


### PR DESCRIPTION
closes #138.

The issue was the outside click handler from the tag selector dropdown that was being triggered on the first click. 

I've amended the useOutsideClick logic to only trigger when the click does not occur in another modal than the one the outside click handler is attached to. Because of the way we currently stack all modals (no two modals are interactable at the same time because they fully overlay the screen), this is an adequate solution.