### PR TITLE
never interpret database types as having optional fields

### DIFF
--- a/shared/types/data/utility.types.ts
+++ b/shared/types/data/utility.types.ts
@@ -21,6 +21,10 @@ export type NullUnused<TUsed, TUnused> = TUsed & {
 	[k in keyof TUnused]: null;
 };
 
+export type NullableOptional<T> = {
+	[P in keyof T]-?: T[P] | null;
+};
+
 /** Type is identical to T except T[K] cannot be optional, if it even was before. */
 export type AtLeast<T, K extends keyof T> = T & Required<Pick<T, K>>;
 


### PR DESCRIPTION
closes #137.

Records from the database cannot have undefined fields, they will always be defined or null. We need to match the data that we get from the database (-> server -> client) to this shape. This helps ensure that we never check for undefined fields, but nullable ones instead.

1. introduce a NullableOptional type
  use this to reshape/cast types that come from the database.
2. use this NullableOptional type in database interaction functions on the server and in client-side data types parsed from fetch functions.
3. fix any functionality in the client-side that is now broken because of the changes in (1) and (2).