### PR TITLE
generalize client api

### DIFF
--- a/client/src/lib/fetch/api.ts
+++ b/client/src/lib/fetch/api.ts
@@ -1,0 +1,49 @@
+import { createRequestConfig } from "@/lib/fetch/create-request-config";
+import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+
+async function apiGet<T>({ url }: { url: string }): Promise<T> {
+	const _url = makeAuthorizedUrl(url);
+	const response: Promise<T> = (
+		await fetch(_url, {
+			credentials: "include",
+			method: "GET"
+		})
+	).json();
+
+	return response;
+}
+
+function apiUpdate(method: "put" | "post") {
+	const configFunction = createRequestConfig[method];
+
+	return async <TInput, TResponse>({
+		url,
+		body
+	}: {
+		url: string;
+		body: TInput;
+	}): Promise<TResponse> => {
+		const _url = makeAuthorizedUrl(url);
+		const response: Promise<TResponse> = (
+			await fetch(_url, configFunction({ body }))
+		).json();
+		return response;
+	};
+}
+
+const apiPost = apiUpdate("post");
+const apiPut = apiUpdate("put");
+
+function apiDelete<T>({ url }: { url: string }): Promise<T> {
+	const _url = makeAuthorizedUrl(url);
+	return (async () => (await fetch(_url, createRequestConfig.delete())).json())();
+}
+
+const api = {
+	get: apiGet,
+	post: apiPost,
+	put: apiPut,
+	delete: apiDelete
+};
+
+export default api;

--- a/client/src/lib/fetch/api.ts
+++ b/client/src/lib/fetch/api.ts
@@ -25,7 +25,7 @@ function apiUpdate(method: "put" | "post") {
 	}): Promise<TResponse> => {
 		const _url = makeAuthorizedUrl(url);
 		const response: Promise<TResponse> = (
-			await fetch(_url, configFunction({ body }))
+			await fetch(_url, configFunction(body))
 		).json();
 		return response;
 	};

--- a/client/src/lib/fetch/api.ts
+++ b/client/src/lib/fetch/api.ts
@@ -3,14 +3,12 @@ import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
 
 async function apiGet<T>({ url }: { url: string }): Promise<T> {
 	const _url = makeAuthorizedUrl(url);
-	const response: Promise<T> = (
+	return (
 		await fetch(_url, {
 			credentials: "include",
 			method: "GET"
 		})
-	).json();
-
-	return response;
+	).json() as T;
 }
 
 function apiUpdate(method: "put" | "post") {
@@ -24,25 +22,19 @@ function apiUpdate(method: "put" | "post") {
 		body: TInput;
 	}): Promise<TResponse> => {
 		const _url = makeAuthorizedUrl(url);
-		const response: Promise<TResponse> = (
-			await fetch(_url, configFunction(body))
-		).json();
-		return response;
+		return (await fetch(_url, configFunction(body))).json() as TResponse;
 	};
 }
 
-const apiPost = apiUpdate("post");
-const apiPut = apiUpdate("put");
-
-function apiDelete<T>({ url }: { url: string }): Promise<T> {
+async function apiDelete<T>({ url }: { url: string }): Promise<T> {
 	const _url = makeAuthorizedUrl(url);
-	return (async () => (await fetch(_url, createRequestConfig.delete())).json())();
+	return (await fetch(_url, createRequestConfig.delete())).json() as T;
 }
 
 const api = {
 	get: apiGet,
-	post: apiPost,
-	put: apiPut,
+	post: apiUpdate("post"),
+	put: apiUpdate("put"),
 	delete: apiDelete
 };
 

--- a/client/src/lib/hooks/query/activities/useActivitiesQuery.ts
+++ b/client/src/lib/hooks/query/activities/useActivitiesQuery.ts
@@ -1,17 +1,11 @@
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { defaultQueryConfig } from "@/lib/query-client";
 import { qk } from "@/lib/query-keys";
 import type { ActivitiesData } from "@/types/data.types";
 import { useQuery } from "@tanstack/react-query";
 
 async function getActivities() {
-	const url = makeAuthorizedUrl("/data/activities");
-	const response = await fetch(url, {
-		credentials: "include",
-		method: "GET"
-	});
-
-	return response.json();
+	return api.get<ActivitiesData>({ url: "/data/activities" });
 }
 
 export default function useActivitiesQuery() {

--- a/client/src/lib/hooks/query/activities/useActivityMutation.ts
+++ b/client/src/lib/hooks/query/activities/useActivityMutation.ts
@@ -1,14 +1,13 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { mk } from "@/lib/query-keys";
 import type { ActivityUpdateInput, ActivityWithIds } from "@t/data/activity.types";
 import { useMutation } from "@tanstack/react-query";
 
 async function putActivity(input: ActivityUpdateInput): Promise<ActivityWithIds> {
-	const url = makeAuthorizedUrl(`/data/activity/${input.activity.activity_id}`);
-	const updatedActivity = (await fetch(url, createRequestConfig.put({ input }))).json();
-
-	return updatedActivity;
+	return api.put<ActivityUpdateInput, ActivityWithIds>({
+		url: `/data/activity/${input.activity.activity_id}`,
+		body: input
+	});
 }
 
 export default function useActivityMutation() {

--- a/client/src/lib/hooks/query/activities/useNewActivityMutation.ts
+++ b/client/src/lib/hooks/query/activities/useNewActivityMutation.ts
@@ -1,16 +1,13 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
+import api from "@/lib/fetch/api";
 import { mk } from "@/lib/query-keys";
-import { makeAuthorizedUrl } from "@lib/fetch/make-authorized-url";
 import type { ActivityInput, ActivityWithIds } from "@t/data/activity.types";
 import { useMutation } from "@tanstack/react-query";
 
 async function postNewActivity(input: ActivityInput): Promise<ActivityWithIds> {
-	const url = makeAuthorizedUrl("/data/activity");
-	const insertedActivity: Promise<ActivityWithIds> = (
-		await fetch(url, createRequestConfig.post(input))
-	).json();
-
-	return insertedActivity;
+	return api.post<ActivityInput, ActivityWithIds>({
+		url: "/data/activity",
+		body: input
+	});
 }
 
 export function useNewActivityMutation() {

--- a/client/src/lib/hooks/query/activities/useTaskMutation.ts
+++ b/client/src/lib/hooks/query/activities/useTaskMutation.ts
@@ -1,5 +1,4 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { queryClient } from "@/lib/query-client";
 import { mk, qk } from "@/lib/query-keys";
 import type { ActivitiesData } from "@/types/data.types";
@@ -7,9 +6,11 @@ import type { ActivityWithIds, TaskUpdateInput } from "@t/data/activity.types";
 import type { ById } from "@t/data/utility.types";
 import { useMutation } from "@tanstack/react-query";
 
-async function putTaskCompletion(input: TaskUpdateInput): Promise<ActivityWithIds> {
-	const url = makeAuthorizedUrl(`/data/task/completion`);
-	return (await fetch(url, createRequestConfig.put({ input }))).json();
+async function putTaskCompletion(input: TaskUpdateInput) {
+	return api.put<TaskUpdateInput, ActivityWithIds>({
+		url: `/data/task/completion`,
+		body: input
+	});
 }
 
 /** Patches the activities cache with a single just-updated activity.

--- a/client/src/lib/hooks/query/habits/useDeleteHabitMutation.ts
+++ b/client/src/lib/hooks/query/habits/useDeleteHabitMutation.ts
@@ -1,13 +1,11 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { queryClient } from "@/lib/query-client";
 import { mk, qk } from "@/lib/query-keys";
 import type { Habit } from "@t/data/habit.types";
 import { useMutation } from "@tanstack/react-query";
 
 async function deleteHabit({ habit_id }: Pick<Habit, "habit_id">) {
-	const url = makeAuthorizedUrl(`/data/habit/${habit_id}`);
-	return (await fetch(url, createRequestConfig.delete())).json();
+	return api.delete<Pick<Habit, "habit_id">>({ url: `/data/habit/${habit_id}` });
 }
 
 export default function useHabitDeleteMutation() {

--- a/client/src/lib/hooks/query/habits/useHabitEntriesQuery.ts
+++ b/client/src/lib/hooks/query/habits/useHabitEntriesQuery.ts
@@ -1,16 +1,11 @@
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { defaultQueryConfig } from "@/lib/query-client";
 import { qk } from "@/lib/query-keys";
 import type { HabitEntriesData } from "@/types/data.types";
 import { useQuery } from "@tanstack/react-query";
 
 async function getHabitEntries() {
-	const url = makeAuthorizedUrl("/data/habit/entries");
-	const response = await fetch(url, {
-		credentials: "include",
-		method: "GET"
-	});
-	return response.json();
+	return api.get<HabitEntriesData>({ url: "/data/habit/entries" });
 }
 
 export default function useHabitEntriesQuery() {

--- a/client/src/lib/hooks/query/habits/useHabitEntryMutation.ts
+++ b/client/src/lib/hooks/query/habits/useHabitEntryMutation.ts
@@ -1,5 +1,4 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { mk } from "@/lib/query-keys";
 import type {
 	HabitEntry,
@@ -18,8 +17,10 @@ export type HabitEntryUpdateMutationFunction = (
 ) => void;
 
 async function putHabitEntry(input: HabitEntryUpdateInput) {
-	const url = makeAuthorizedUrl("/data/habit/entry");
-	return (await fetch(url, createRequestConfig.put({ input }))).json();
+	return api.put<HabitEntryUpdateInput, HabitEntry>({
+		url: "/data/habit/entry",
+		body: input
+	});
 }
 
 export default function useHabitEntryMutation() {

--- a/client/src/lib/hooks/query/habits/useHabitsQuery.ts
+++ b/client/src/lib/hooks/query/habits/useHabitsQuery.ts
@@ -1,17 +1,11 @@
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { defaultQueryConfig } from "@/lib/query-client";
 import { qk } from "@/lib/query-keys";
 import type { HabitsData } from "@/types/data.types";
 import { useQuery } from "@tanstack/react-query";
 
 async function getHabits() {
-	const url = makeAuthorizedUrl("/data/habits");
-	const response = await fetch(url, {
-		credentials: "include",
-		method: "GET"
-	});
-
-	return response.json();
+	return api.get<HabitsData>({ url: "/data/habits" });
 }
 
 export default function useHabitsQuery() {

--- a/client/src/lib/hooks/query/habits/useNewHabitEntryMutation.ts
+++ b/client/src/lib/hooks/query/habits/useNewHabitEntryMutation.ts
@@ -1,12 +1,13 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { mk } from "@/lib/query-keys";
 import type { HabitEntry, HabitEntryInput } from "@t/data/habit.types";
 import { useMutation } from "@tanstack/react-query";
 
-async function postHabitEntry({ habitEntry }: HabitEntryInput) {
-	const url = makeAuthorizedUrl("/data/habit/entry");
-	return (await fetch(url, createRequestConfig.post({ habitEntry }))).json();
+async function postHabitEntry(input: HabitEntryInput) {
+	return api.post<HabitEntryInput, HabitEntry>({
+		url: "/data/habit/entry",
+		body: input
+	});
 }
 
 export default function useNewHabitEntryMutation() {

--- a/client/src/lib/hooks/query/habits/useNewHabitMutation.ts
+++ b/client/src/lib/hooks/query/habits/useNewHabitMutation.ts
@@ -1,16 +1,10 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { makeAuthorizedUrl } from "@/lib/fetch/make-authorized-url";
+import api from "@/lib/fetch/api";
 import { mk } from "@/lib/query-keys";
 import type { HabitInput, HabitWithIds } from "@t/data/habit.types";
 import { useMutation } from "@tanstack/react-query";
 
-async function postNewHabit({ habit, tagIds }: HabitInput): Promise<HabitWithIds> {
-	const url = makeAuthorizedUrl("/data/habit");
-	const insertedHabit: Promise<HabitWithIds> = (
-		await fetch(url, createRequestConfig.post({ habit, tagIds }))
-	).json();
-
-	return insertedHabit;
+async function postNewHabit(input: HabitInput): Promise<HabitWithIds> {
+	return api.post<HabitInput, HabitWithIds>({ url: "/data/habit", body: input });
 }
 
 export function useNewHabitMutation() {

--- a/client/src/lib/hooks/query/notes/useNewNoteMutation.ts
+++ b/client/src/lib/hooks/query/notes/useNewNoteMutation.ts
@@ -1,12 +1,10 @@
+import api from "@/lib/fetch/api";
 import { mk } from "@/lib/query-keys";
-import { createRequestConfig } from "@lib/fetch/create-request-config";
-import { makeAuthorizedUrl } from "@lib/fetch/make-authorized-url";
 import type { NoteInput, NoteWithIds } from "@t/data/note.types";
 import { useMutation } from "@tanstack/react-query";
 
-async function postNote({ note, tagIds }: NoteInput) {
-	const url = makeAuthorizedUrl("/data/note");
-	return (await fetch(url, createRequestConfig.post({ note, tagIds }))).json();
+async function postNote(input: NoteInput) {
+	return api.post<NoteInput, NoteWithIds>({ url: "/data/note", body: input });
 }
 
 export function useNewNoteMutation() {

--- a/client/src/lib/hooks/query/notes/useNotesQuery.ts
+++ b/client/src/lib/hooks/query/notes/useNotesQuery.ts
@@ -1,17 +1,11 @@
+import api from "@/lib/fetch/api";
 import { qk } from "@/lib/query-keys";
 import type { NotesData } from "@/types/data.types";
-import { makeAuthorizedUrl } from "@lib/fetch/make-authorized-url";
 import { defaultQueryConfig } from "@lib/query-client";
 import { useQuery } from "@tanstack/react-query";
 
 async function getNotes() {
-	const url = makeAuthorizedUrl("/data/notes");
-	const response = await fetch(url, {
-		credentials: "include",
-		method: "GET"
-	});
-
-	return response.json();
+	return api.get<NotesData>({ url: "/data/notes" });
 }
 
 export default function useNotesQuery() {

--- a/client/src/lib/hooks/query/tags/useTagsQuery.ts
+++ b/client/src/lib/hooks/query/tags/useTagsQuery.ts
@@ -1,27 +1,19 @@
+import api from "@/lib/fetch/api";
 import { qk } from "@/lib/query-keys";
 import type { TagsData } from "@/types/data.types";
-import { makeAuthorizedUrl } from "@lib/fetch/make-authorized-url";
 import { defaultQueryConfig, queryClient } from "@lib/query-client";
 import { useQuery } from "@tanstack/react-query";
 
 async function getTags() {
-	const url = makeAuthorizedUrl("/data/tags");
-	const response = await fetch(url, {
-		credentials: "include",
-		method: "GET"
-	});
-
-	// TODO: when tags are fetched, tree also -- maybe this means we should put
-	// them into a single query
+	// TODO: when tags are fetched, tree needs to be fetched, too -- maybe this
+	// means we should put them into a single query
+	const response = api.get<TagsData>({ url: "/data/tags" });
 	queryClient.invalidateQueries({ queryKey: qk.tags.tree });
-	return response.json();
+	return response;
 }
 
 export default function useTagsQuery() {
 	return useQuery<TagsData>({
-		// TODO: if someone switches accounts, they might get the wrong tags --
-		// make sure to invalidate all user-data queries when the user changes, or
-		// add user_id to the queryKey
 		queryKey: qk.tags.all,
 		queryFn: getTags,
 		...defaultQueryConfig

--- a/client/src/lib/hooks/query/tags/useTagsTreeQuery.ts
+++ b/client/src/lib/hooks/query/tags/useTagsTreeQuery.ts
@@ -1,23 +1,15 @@
+import api from "@/lib/fetch/api";
 import { qk } from "@/lib/query-keys";
 import type { TagsTreeData } from "@/types/data.types";
-import { makeAuthorizedUrl } from "@lib/fetch/make-authorized-url";
 import { defaultQueryConfig } from "@lib/query-client";
 import { useQuery } from "@tanstack/react-query";
 
 export async function getTagsTree() {
-	const url = makeAuthorizedUrl("/data/tags/tree");
-	const response = await fetch(url, {
-		credentials: "include",
-		method: "GET"
-	});
-	return response.json();
+	return api.get<TagsTreeData>({ url: "/data/tags/tree" });
 }
 
 export default function useTagsTreeQuery() {
 	return useQuery<TagsTreeData>({
-		// TODO: if someone switches accounts, they might get the wrong tags --
-		// make sure to invalidate all user-data queries when the user changes, or
-		// add user_id to the queryKey
 		queryKey: qk.tags.tree,
 		queryFn: getTagsTree,
 		...defaultQueryConfig

--- a/client/src/lib/hooks/query/user/useLoginMutation.ts
+++ b/client/src/lib/hooks/query/user/useLoginMutation.ts
@@ -1,5 +1,4 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { baseUrl } from "@/lib/fetch/fetch-constants";
+import api from "@/lib/fetch/api";
 import { mk, qk } from "@/lib/query-keys";
 import { localUser } from "@/lib/user-storage";
 import type { Data } from "@/types/query.types";
@@ -7,9 +6,10 @@ import type { User, UserLogin } from "@t/data/user.types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 async function postLogin(user: UserLogin) {
-	return (
-		await fetch(`${baseUrl}/auth/login`, createRequestConfig.post({ user }))
-	).json();
+	return api.post<{ user: UserLogin }, Data<"user", User>>({
+		url: "/auth/login",
+		body: { user }
+	});
 }
 
 export default function useLoginMutation() {

--- a/client/src/lib/hooks/query/user/useLogoutMutation.ts
+++ b/client/src/lib/hooks/query/user/useLogoutMutation.ts
@@ -1,5 +1,4 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { baseUrl } from "@/lib/fetch/fetch-constants";
+import api from "@/lib/fetch/api";
 import useRouteProps from "@/lib/hooks/useRouteProps";
 import { queryClient } from "@/lib/query-client";
 import { mk, qk } from "@/lib/query-keys";
@@ -7,7 +6,7 @@ import { localUser } from "@/lib/user-storage";
 import { useMutation } from "@tanstack/react-query";
 
 async function postLogout() {
-	return (await fetch(`${baseUrl}/auth/logout`, createRequestConfig.post())).json();
+	return api.post<unknown, unknown>({ url: "/auth/logout", body: {} });
 }
 
 export default function useLogoutMutation() {

--- a/client/src/lib/hooks/query/user/useMeQuery.ts
+++ b/client/src/lib/hooks/query/user/useMeQuery.ts
@@ -1,18 +1,12 @@
-import { baseUrl } from "@/lib/fetch/fetch-constants";
+import api from "@/lib/fetch/api";
 import { defaultQueryConfig } from "@/lib/query-client";
 import { qk } from "@/lib/query-keys";
 import { localUser } from "@/lib/user-storage";
-import type { Data } from "@/types/query.types";
-import type { User } from "@t/data/user.types";
-import type { Maybe } from "@t/data/utility.types";
+import type { UserData } from "@/types/data.types";
 import { useQuery } from "@tanstack/react-query";
 
 export async function getMe() {
-	const response = await fetch(`${baseUrl}/auth/me`, {
-		credentials: "include",
-		method: "GET"
-	});
-	const data = await response.json();
+	const data = await api.get<UserData>({ url: "/auth/me" });
 
 	if (data.user) {
 		localUser.set(data.user);
@@ -22,8 +16,6 @@ export async function getMe() {
 
 	return data;
 }
-
-type UserData = Data<"user", Maybe<User>>;
 
 export default function useMeQuery() {
 	return useQuery<UserData>({

--- a/client/src/lib/hooks/query/user/useRegisterMutation.ts
+++ b/client/src/lib/hooks/query/user/useRegisterMutation.ts
@@ -1,21 +1,25 @@
-import { createRequestConfig } from "@/lib/fetch/create-request-config";
-import { baseUrl } from "@/lib/fetch/fetch-constants";
+import api from "@/lib/fetch/api";
+import useRouteProps from "@/lib/hooks/useRouteProps";
 import { mk } from "@/lib/query-keys";
-import type { Data } from "@/types/query.types";
-import type { NewUser, User } from "@t/data/user.types";
+import type { UserData } from "@/types/data.types";
+import type { NewUser } from "@t/data/user.types";
 import { useMutation } from "@tanstack/react-query";
 
 async function postRegister(newUser: NewUser) {
-	return (
-		await fetch(`${baseUrl}/auth/register`, createRequestConfig.post({ newUser }))
-	).json();
+	return api.post<{ newUser: NewUser }, UserData>({
+		url: "/auth/register",
+		body: { newUser }
+	});
 }
 
 export default function useRegisterMutation() {
-	return useMutation<Data<"user", User>, unknown, NewUser>({
+	const { navigate } = useRouteProps();
+
+	return useMutation<UserData, unknown, NewUser>({
 		async mutationFn(newUser) {
 			return postRegister(newUser);
 		},
-		mutationKey: mk.user.register
+		mutationKey: mk.user.register,
+		onSuccess: () => navigate("/")
 	});
 }

--- a/client/src/types/data.types.ts
+++ b/client/src/types/data.types.ts
@@ -2,7 +2,9 @@ import type { ActivityWithIds } from "@t/data/activity.types";
 import type { HabitEntry, HabitWithIds } from "@t/data/habit.types";
 import type { NoteWithIds } from "@t/data/note.types";
 import type { TagWithIds } from "@t/data/tag.types";
-import type { DataById } from "./query.types";
+import type { User } from "@t/data/user.types";
+import type { Maybe } from "@t/data/utility.types";
+import type { Data, DataById } from "./query.types";
 
 // TODO: all these types come from the backend, so they should be moved to the
 // server folder, and also be used directly on the server.
@@ -13,3 +15,5 @@ export type NotesData = DataById<NoteWithIds>;
 export type TagsTreeData = DataById<{ members: number[] }>;
 export type HabitsData = DataById<HabitWithIds>;
 export type HabitEntriesData = DataById<HabitEntry>;
+
+export type UserData = Data<"user", Maybe<User>>;

--- a/server/src/routers/auth.ts
+++ b/server/src/routers/auth.ts
@@ -36,5 +36,4 @@ authRouter.post("/register", async (req, res) => {
 	}
 
 	await login(newUser, req, res);
-	return res.status(200).json({ user: registeredUser });
 });


### PR DESCRIPTION
This closes #31. Future work (error handling, etc.) is out of scope for that issue.

- create a single `api` object that exposes GET, PUT, POST, DELETE functions that take type generics for input and output types.
- use these api functions for all our `queryFn` and `mutationFn` functions.
- (oos) register endpoint tried to res.json() twice (once in the internal login function, and once by itself) which was causing crashes (cannot send headers after...)
- (oos) in the client, on successful register, navigate to index route