### PR TITLE
styled-components + vite + babel

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "^7.15.0",
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/ui": "^2.1.5",
+    "babel-plugin-styled-components": "^2.1.4",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.35.0",

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,19 +4,28 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react(), tsconfigPaths()],
-    resolve: {
-        alias: {
-            "@": path.resolve(__dirname, "../client/src"),
-            "@lib": path.resolve(__dirname, "../client/src/lib"),
-            "@components": path.resolve(__dirname, "../client/src/components"),
-            "@t": path.resolve(__dirname, "../shared/types")
-        },
-        extensions: [".js", ".jsx", ".ts", ".tsx", ".json"]
-    },
-    server: {
-        watch: {
-            usePolling: true
-        }
-    }
+	plugins: [
+		react({
+			babel: {
+				plugins: ["styled-components"],
+				babelrc: false,
+				configFile: false
+			}
+		}),
+		tsconfigPaths()
+	],
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "../client/src"),
+			"@lib": path.resolve(__dirname, "../client/src/lib"),
+			"@components": path.resolve(__dirname, "../client/src/components"),
+			"@t": path.resolve(__dirname, "../shared/types")
+		},
+		extensions: [".js", ".jsx", ".ts", ".tsx", ".json"]
+	},
+	server: {
+		watch: {
+			usePolling: true
+		}
+	}
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@typescript-eslint/parser": "^7.15.0",
         "@vitejs/plugin-react": "^4.3.1",
         "@vitest/ui": "^2.1.5",
+        "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react": "^7.35.0",
@@ -4821,6 +4822,22 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-plugin-styled-components": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {


### PR DESCRIPTION
Now that I'm starting to use Storybook a bit more, and for better readability in (React) dev tools, install a babel plugin for styled components that fixes the generic class and display names.