### PR TITLE
do not use default value for end date in DateTimePicker (#151)

### DIFF
--- a/client/src/components/activities/ActivityForm/DateTimePicker.tsx
+++ b/client/src/components/activities/ActivityForm/DateTimePicker.tsx
@@ -8,9 +8,9 @@ import useDateTimePicker from "./useDateTimePicker";
 export default function DateTimePicker({ onChange, defaultValues }: DateTimePickerProps) {
 	const {
 		allDay,
+		date,
 		manualEndDate,
 		defaultStartDate,
-		defaultEndDate,
 		defaultTime,
 		onAllDayFieldChange,
 		onStartDateFieldChange,
@@ -38,7 +38,7 @@ export default function DateTimePicker({ onChange, defaultValues }: DateTimePick
 						<span>End date</span>
 						<DefaultInput
 							type="date"
-							defaultValue={defaultEndDate}
+							value={date.end}
 							onChange={onEndDateFieldChange}
 						/>
 					</S.Label>

--- a/client/src/components/activities/ActivityForm/useDateTimePicker.ts
+++ b/client/src/components/activities/ActivityForm/useDateTimePicker.ts
@@ -135,15 +135,12 @@ export default function useDateTimePicker({
 	const defaultStartDate = defaultStartAndEnd?.start
 		? formatToYearMonthDay(defaultStartAndEnd.start)
 		: date.start;
-	const defaultEndDate = defaultStartAndEnd?.end
-		? formatToYearMonthDay(defaultStartAndEnd.end)
-		: date.end;
 
 	return {
 		allDay,
+		date,
 		manualEndDate,
 		defaultStartDate,
-		defaultEndDate,
 		defaultTime,
 		onAllDayFieldChange,
 		onStartDateFieldChange,


### PR DESCRIPTION
Closes #151.

Instead of using the `defaultEndDate` as a `defaultValue` in the end date field, use the actual `date.end` state value, because that one is reactive to the start date state, which is what we want (if `endDate` hasn't been modified by the user, we want the end date to always shift to at least the start date whenever the start date changes).