### PR TITLE
replace most usage of `Datelike` with `Dayjs`

### DIFF
--- a/client/src/components/Today/Activity.tsx
+++ b/client/src/components/Today/Activity.tsx
@@ -2,10 +2,10 @@ import { activityDurationOnDate, activityStartOnDate } from "@/lib/activity";
 import useDetailedItemModal from "@/lib/hooks/useDetailedItemModal";
 import modalIds from "@/lib/modal-ids";
 import type { ActivityWithIds } from "@t/data/activity.types";
-import type { Datelike } from "@t/data/utility.types";
+import type { Dayjs } from "dayjs";
 import T from "./style/Activity.style";
 
-function useActivity(activity: ActivityWithIds, date: Datelike) {
+function useActivity(activity: ActivityWithIds, date: Dayjs) {
 	const start = activityStartOnDate(activity, date);
 	const offset = !start ? 0 : start.minute() / 60;
 	const { openDetailedItemModal } = useDetailedItemModal(
@@ -27,7 +27,7 @@ function useActivity(activity: ActivityWithIds, date: Datelike) {
 export type ActivityProps = {
 	activity: ActivityWithIds;
 	level: number;
-	date: Datelike;
+	date: Dayjs;
 };
 
 export default function Activity({ activity, level, date }: ActivityProps) {

--- a/client/src/components/Today/Notes.tsx
+++ b/client/src/components/Today/Notes.tsx
@@ -1,4 +1,5 @@
 import Empty from "@/components/Today/Empty";
+import { createDate } from "@/lib/datetime/make-date";
 import { filterTagsById } from "@/lib/filter-tags";
 import useNotesQuery from "@/lib/hooks/query/notes/useNotesQuery";
 import useTagsQuery from "@/lib/hooks/query/tags/useTagsQuery";
@@ -14,7 +15,7 @@ export default function Notes() {
 		// TODO: note.date is not a field in the client when creating a new note,
 		// so it will always be undefined currently, so using created_at is a
 		// temporary solution.
-		isToday(note.date ?? note.created_at)
+		isToday(note.date ? createDate(note.date) : createDate(note.created_at))
 	);
 	return (
 		<S.NotesWrapper>

--- a/client/src/components/Today/TimelineRow.tsx
+++ b/client/src/components/Today/TimelineRow.tsx
@@ -2,13 +2,14 @@ import CurrentTimeMark from "@/components/Today/CurrentTimeMark";
 import { isToday } from "@/lib/datetime/compare";
 import useCurrentTime from "@/lib/hooks/useCurrentTime";
 import type { ActivityWithIds } from "@t/data/activity.types";
-import type { Datelike, ID } from "@t/data/utility.types";
+import type { ID } from "@t/data/utility.types";
+import type { Dayjs } from "dayjs";
 import Activity from "./Activity";
 import HourMark from "./HourMark";
 import R from "./style/TimelineRow.style";
 
 type RowProps = {
-	date: Datelike;
+	date: Dayjs;
 	/** `index` is a number [0,24] that represents the hour of the day. Index 24
 	 * refers to midnight of the following day and is only there for display
 	 * purposes. */

--- a/client/src/components/Today/TimelineRows.tsx
+++ b/client/src/components/Today/TimelineRows.tsx
@@ -4,7 +4,7 @@ import {
 	assignIndentationLevelToActivities
 } from "@/lib/activity";
 import type { ActivityWithIds } from "@t/data/activity.types";
-import type { Datelike } from "@t/data/utility.types";
+import type { Dayjs } from "dayjs";
 import S from "./style/Today.style";
 
 function useRows({
@@ -14,7 +14,7 @@ function useRows({
 	activities: ActivityWithIds[];
 	/** `currentDate` will change to `date` once we make Today take a date as a
 	 * prop. */
-	currentDate: Datelike;
+	currentDate: Dayjs;
 }) {
 	const indentation = assignIndentationLevelToActivities(activities, currentDate);
 
@@ -25,7 +25,7 @@ function useRows({
 
 type RowsProps = {
 	activities: ActivityWithIds[];
-	currentDate: Datelike;
+	currentDate: Dayjs;
 };
 
 export default function TimelineRows({ activities, currentDate }: RowsProps) {

--- a/client/src/lib/activity.test.ts
+++ b/client/src/lib/activity.test.ts
@@ -1,10 +1,11 @@
 import { activityFallsOnDay } from "@/lib/activity";
+import { createDate } from "@/lib/datetime/make-date";
 import type { ActivityWithIds } from "@t/data/activity.types";
 
 describe("activityFallsOnDay", () => {
 	const mockActivity: ActivityWithIds = {
-		start_date: "2021-01-01",
-		end_date: "2021-01-02",
+		start_date: "2024-01-01",
+		end_date: "2024-01-02",
 		started_at: null,
 		ended_at: null,
 		activity_id: 0,
@@ -17,13 +18,13 @@ describe("activityFallsOnDay", () => {
 	};
 
 	it("returns true if activity falls on day", () => {
-		const date = "2021-01-01";
+		const date = createDate("2024-01-01");
 
 		expect(activityFallsOnDay(mockActivity, date)).toBe(true);
 	});
 
 	it("returns false if activity does not fall on day", () => {
-		const date = "2021-01-03";
+		const date = createDate("1995-01-03");
 
 		expect(activityFallsOnDay(mockActivity, date)).toBe(false);
 	});

--- a/client/src/lib/datetime/compare.ts
+++ b/client/src/lib/datetime/compare.ts
@@ -1,10 +1,10 @@
-import type { Datelike } from "@t/data/utility.types";
-import { createDate, today } from "./make-date";
+import type { Dayjs } from "dayjs";
+import { today } from "./make-date";
 
-export function sameDay(one: Datelike, two: Datelike) {
-	return createDate(one).isSame(createDate(two), "day");
+export function sameDay(one: Dayjs, two: Dayjs) {
+	return one.isSame(two, "day");
 }
 
-export function isToday(date: Datelike) {
-	return createDate(date).isSame(today(), "day");
+export function isToday(date: Dayjs) {
+	return date.isSame(today(), "day");
 }

--- a/client/src/lib/datetime/tests/compare.test.ts
+++ b/client/src/lib/datetime/tests/compare.test.ts
@@ -6,12 +6,12 @@ describe("datetime/compare", () => {
 		it("should return true if two dates are the same day", () => {
 			const one = new Date(2024, 11, 19);
 			const two = new Date(2024, 11, 19);
-			expect(sameDay(one, two)).toBe(true);
+			expect(sameDay(createDate(one), createDate(two))).toBe(true);
 		});
 		it("should return false if two dates are not the same day", () => {
 			const one = new Date(2024, 11, 19);
 			const two = new Date(2024, 11, 20);
-			expect(sameDay(one, two)).toBe(false);
+			expect(sameDay(createDate(one), createDate(two))).toBe(false);
 
 			const midnight = createDate(one).endOf("day");
 			const minuteAfterMidnight = midnight.add(1, "millisecond");
@@ -22,10 +22,8 @@ describe("datetime/compare", () => {
 	describe("isToday", () => {
 		it("should return true if the date is today", () => {
 			const currentTimeAndDate = now();
-			const currentTimeAndDateAsDate = currentTimeAndDate.toDate();
 
 			expect(isToday(currentTimeAndDate)).toBe(true);
-			expect(isToday(currentTimeAndDateAsDate)).toBe(true);
 
 			expect(isToday(currentTimeAndDate.startOf("day"))).toBe(true);
 		});


### PR DESCRIPTION
I was noticing some slower renders, and React was seriously struggling to keep up with all the changing state in dev mode when changing `timeWindow` rapidly a number of times in `Today`. One of the slowest tasks was the generation of the appropriate timeline items, because of the amount of times we were converting things to dayjs even though we're already basically always using Dayjs types instead of Dates, strings or unix timestamps.

I guess this relates also to #54. We need a mechanism to convert any and all time fields that we get from the API and convert them to Dayjs right away. Then we can replace, at least in the client (I guess if we do the same thing when going from database to serve, e.g. in a custom type parser in the sql object, we can do it there too), most usage of Datelike with Dayjs.

For the single use case that triggered this PR, we can make things even more performant by memoizing the relevant checks, but I don't see how that's the best use of my time right now. This PR halves (in dev mode, and I guess in production the issue wouldn't've been noticable at all anyway) the render time of the TimelineRows, so I'm happy for now.