### PR TITLE
modal scrollability (TRK-115)

### DIFF
--- a/client/src/components/utility/Modal/Modal.tsx
+++ b/client/src/components/utility/Modal/Modal.tsx
@@ -40,7 +40,7 @@ export default function Modal({
 		>
 			<S.Modal ref={modalRef} data-modal-id={modalId}>
 				<S.Close onClick={handleModalClose} $color="red" />
-				{children}
+				<S.ModalChildWrapper>{children}</S.ModalChildWrapper>
 			</S.Modal>
 		</S.ModalWrapper>
 	);

--- a/client/src/components/utility/Modal/style/Modal.style.ts
+++ b/client/src/components/utility/Modal/style/Modal.style.ts
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 const ModalWrapper = styled.div`
 	--modal-offset: 5vh;
-	@media (min-height: 1280px) {
+	@media (min-height: 1080px) {
 		--modal-offset: 25vh;
 	}
 	overflow: hidden;
@@ -28,15 +28,14 @@ const Close = styled(Action.Stylized)`
 `;
 
 const Modal = styled.div`
+	border: 2px solid orange;
 	position: relative;
 	${spacing.padding.wide({ size: 1.2, ratio: 1.25 })}
 	background-color: #eee; // TODO: this should be a theme value
 	height: max-content;
-	margin-top: var(
-		--modal-offset
-	); // TODO: this should be responsive, so should everything else obviously
 	border: 1px solid #444;
 	border-radius: 5px;
+	margin-top: var(--modal-offset);
 	box-shadow:
 		0.8rem 0.8rem 0.1rem -0.2rem #ddd,
 		1.1rem -0.5rem 0.1rem -0.2rem ${(p) => p.theme.colors.blue.main};
@@ -45,7 +44,7 @@ const Modal = styled.div`
 const ModalChildWrapper = styled.div`
 	overflow-y: auto;
 	${scrollbar.hidden};
-	max-height: calc(95vh - var(--modal-offset));
+	max-height: calc(90vh - var(--modal-offset));
 `;
 
 export default { ModalWrapper, Close, Modal, ModalChildWrapper };

--- a/client/src/components/utility/Modal/style/Modal.style.ts
+++ b/client/src/components/utility/Modal/style/Modal.style.ts
@@ -1,8 +1,13 @@
 import { Action } from "@/lib/theme/components/buttons";
+import scrollbar from "@/lib/theme/snippets/scroll";
 import { spacing } from "@/lib/theme/snippets/spacing";
 import styled from "styled-components";
 
 const ModalWrapper = styled.div`
+	--modal-offset: 5vh;
+	@media (min-height: 1280px) {
+		--modal-offset: 25vh;
+	}
 	overflow: hidden;
 	z-index: 100; // TODO: should put these indexes somewhere so we can reason about them
 	position: fixed;
@@ -27,7 +32,9 @@ const Modal = styled.div`
 	${spacing.padding.wide({ size: 1.2, ratio: 1.25 })}
 	background-color: #eee; // TODO: this should be a theme value
 	height: max-content;
-	margin-top: 25vh; // TODO: this should be responsive, so should everything else obviously
+	margin-top: var(
+		--modal-offset
+	); // TODO: this should be responsive, so should everything else obviously
 	border: 1px solid #444;
 	border-radius: 5px;
 	box-shadow:
@@ -35,4 +42,10 @@ const Modal = styled.div`
 		1.1rem -0.5rem 0.1rem -0.2rem ${(p) => p.theme.colors.blue.main};
 `;
 
-export default { ModalWrapper, Close, Modal };
+const ModalChildWrapper = styled.div`
+	overflow-y: auto;
+	${scrollbar.hidden};
+	max-height: calc(95vh - var(--modal-offset));
+`;
+
+export default { ModalWrapper, Close, Modal, ModalChildWrapper };

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -6,6 +6,11 @@ html {
 	color: var(--text-light);
 	height: 100%;
 	overflow-y: scroll;
+
+	// Disables overflow when there is at least one open modal.
+	&:has([data-modal-id]) {
+		overflow: hidden;
+	}
 }
 
 body {


### PR DESCRIPTION
Larger modals, and modals on not-so-tall viewports, would overflow, but wouldn't be scrollable because of the overflow styling applied to the modal wrapper.

- by default, when there is any active modal, the regular content now has `overflow: hidden`. This is to prevent scrolling of the content behind the modal.
- made the position of the modal a bit more responsive. On less tall viewports, it has less top margin. The old margin is now only applied on taller viewports.
- limit the maximum height of modal content to make it so the wrapper itself never overflows. Instead, apply styling to the modal content itself to make it scrollable when it overflows the modal wrapper. The modal content has no visible scrollbar, because I want to apply custom styling for this. 