### PR TITLE
month-change buttons

### DIFF
--- a/client/src/components/utility/Calendar/Calendar.tsx
+++ b/client/src/components/utility/Calendar/Calendar.tsx
@@ -6,6 +6,7 @@ import { Cell } from "@/lib/theme/components/buttons";
 import { MonthPicker } from "@mantine/dates";
 import type { Maybe } from "@t/data/utility.types";
 import type { Dayjs } from "dayjs";
+import { LucideChevronLeft, LucideChevronRight } from "lucide-react";
 import S from "./style/Calendar.style";
 
 type CalendarRowProps = {
@@ -42,6 +43,21 @@ function CalendarRow({ month, year, row, selectDate, selectedDate }: CalendarRow
 	);
 }
 
+type AdjacentMonthButtonProps = {
+	direction: "previous" | "next";
+	onClick: () => void;
+	size?: number;
+};
+
+function AdjacentMonthButton({ direction, onClick }: AdjacentMonthButtonProps) {
+	const Icon = direction === "next" ? LucideChevronRight : LucideChevronLeft;
+	return (
+		<S.MonthPickerAction $direction={direction} onClick={onClick}>
+			<Icon size={22} />
+		</S.MonthPickerAction>
+	);
+}
+
 export default function Calendar({
 	initialDate,
 	onChange: setExternalState
@@ -52,8 +68,13 @@ export default function Calendar({
 			onChange: setExternalState
 		});
 
-	const { handleMonthChange, showMonthPicker, setShowMonthPicker, monthValue } =
-		useMonthPicker({ initialDate, onChange: setMonthAndYear });
+	const {
+		handleMonthChange,
+		showMonthPicker,
+		setShowMonthPicker,
+		monthValue,
+		handleArrowClick
+	} = useMonthPicker({ initialDate, onChange: setMonthAndYear });
 
 	return (
 		<S.Calendar>
@@ -68,6 +89,16 @@ export default function Calendar({
 				</S.MonthPickerWrapper>
 			)}
 			<S.TitleWrapper>
+				<S.MonthPickerActionWrapper>
+					<AdjacentMonthButton
+						direction="previous"
+						onClick={() => handleArrowClick("previous")}
+					/>
+					<AdjacentMonthButton
+						direction="next"
+						onClick={() => handleArrowClick("next")}
+					/>
+				</S.MonthPickerActionWrapper>
 				<S.Title onClick={() => setShowMonthPicker(true)}>{title}</S.Title>
 			</S.TitleWrapper>
 			<S.Days>

--- a/client/src/components/utility/Calendar/hooks/useMonthPicker.ts
+++ b/client/src/components/utility/Calendar/hooks/useMonthPicker.ts
@@ -1,7 +1,7 @@
 import type { MonthAndYear } from "@/components/utility/Calendar/calendar.types";
 import type { DateValue } from "@mantine/dates";
 import type { Dayjs } from "dayjs";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type UseMonthPickerProps = {
 	initialDate: Dayjs;
@@ -18,11 +18,25 @@ export default function useMonthPicker({ initialDate, onChange }: UseMonthPicker
 		if (!value) return;
 
 		setMonthValue(value);
-		onChange?.({
-			month: value.getMonth(),
-			year: value.getFullYear()
-		});
 		setShowMonthPicker(false);
+	}
+
+	useEffect(() => {
+		if (!monthValue) return;
+
+		onChange?.({
+			month: monthValue.getMonth(),
+			year: monthValue.getFullYear()
+		});
+	}, [monthValue]);
+
+	function handleArrowClick(direction: "previous" | "next") {
+		setMonthValue((current) => {
+			const modifier = direction === "previous" ? -1 : 1;
+			const newDate = new Date(current);
+			newDate.setMonth(newDate.getMonth() + modifier);
+			return newDate;
+		});
 	}
 
 	return {
@@ -30,6 +44,7 @@ export default function useMonthPicker({ initialDate, onChange }: UseMonthPicker
 		setShowMonthPicker,
 		monthValue,
 		setMonthValue,
-		handleMonthChange
+		handleMonthChange,
+		handleArrowClick
 	};
 }

--- a/client/src/components/utility/Calendar/style/Calendar.style.ts
+++ b/client/src/components/utility/Calendar/style/Calendar.style.ts
@@ -1,3 +1,4 @@
+import { Unstyled } from "@/lib/theme/components/buttons";
 import { defaultCellHeight, defaultCellWidth } from "@/lib/theme/components/buttons/Cell";
 import { getFontSize } from "@/lib/theme/font";
 import { flex } from "@/lib/theme/snippets/flex";
@@ -32,13 +33,14 @@ const TitleWrapper = styled.div`
 	width: 100%;
 
 	${flex.row};
-	justify-content: flex-end;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 0.2rem;
 `;
 
 const Title = styled.h2`
 	font-size: ${(p) => getFontSize(p, 1.2)};
 	color: ${highlightColor};
-	margin-bottom: calc(4 * ${gap});
 `;
 
 const MonthPickerWrapper = styled.div`
@@ -92,6 +94,45 @@ const Row = styled.div`
 	gap: ${gap};
 `;
 
+const MonthPickerActionWrapper = styled.div`
+	${flex.row};
+	gap: 0.5rem;
+
+	svg {
+		cursor: pointer;
+		color: #333;
+	}
+`;
+
+const MonthPickerAction = styled(Unstyled)<{
+	$direction: "previous" | "next";
+}>`
+	transition: transform 50ms ease-out;
+
+	border-bottom: 2px solid transparent;
+	display: flex;
+	align-items: center;
+
+	&:hover,
+	&:active,
+	&:focus {
+		border-bottom-color: ${highlightColor};
+
+		transform: translateX(
+				${(p) => (p.$direction === "previous" ? "-0.1rem" : "0.1rem")}
+			)
+			scaleX(1.05);
+
+		svg {
+			color: ${highlightColor};
+		}
+	}
+`;
+
+MonthPickerAction.defaultProps = {
+	type: "button"
+};
+
 export default {
 	Calendar,
 	TitleWrapper,
@@ -100,5 +141,7 @@ export default {
 	Days,
 	Day,
 	Rows,
-	Row
+	Row,
+	MonthPickerActionWrapper,
+	MonthPickerAction
 };


### PR DESCRIPTION
- in the calendar, implements a previous and a next button to quickly change to the corresponding month
- added a `useEffect` inside `useMonthPicker` that calls the external `onChange` whenever the `monthValue` changes

Screenshot:
![image](https://github.com/user-attachments/assets/0b3fd858-76b8-4c1f-8070-91f3eca98cb8)
