### PR TITLE
better two-way binding between `Today` and calendar hooks

### DIFF
--- a/client/src/components/Today/Today.tsx
+++ b/client/src/components/Today/Today.tsx
@@ -5,91 +5,17 @@ import NewNote from "@/components/notes/NewNote/NewNote";
 import AllDayActivities from "@/components/Today/AllDayActivities";
 import ChangeDayButton from "@/components/Today/ChangeDayButton";
 import TimelineRows from "@/components/Today/TimelineRows";
+import useToday from "@/components/Today/useToday";
 import Calendar from "@/components/utility/Calendar/Calendar";
 import Modal from "@/components/utility/Modal/Modal";
 import SpeedDial from "@/components/utility/SpeedDial/SpeedDial";
-import { today } from "@/lib/datetime/make-date";
-import useQueryActivities from "@/lib/hooks/query/activities/useQueryActivities";
-import useHabitsData from "@/lib/hooks/useHabitsData";
 import type { ModalId } from "@/lib/modal-ids";
 import modalIds from "@/lib/modal-ids";
 import { useModalState } from "@/lib/state/modal-state";
-import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
-import { activityFallsOnDay, isAllDayActivityOnDate } from "@lib/activity";
-import type { Dayjs } from "dayjs";
 import type { PropsWithChildren } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useRecoilState } from "recoil";
 import Notes from "./Notes";
 import S from "./style/Today.style";
 import Tasks from "./Tasks";
-
-/** Functionality hook for the Today component. */
-function useToday() {
-	const { data: activitiesData } = useQueryActivities();
-	const { getHabitsForTimeWindow } = useHabitsData();
-	const [currentDate, setCurrentDate] = useState<Dayjs>(() => today());
-	const [timeWindow, setTimeWindow] = useRecoilState(selectedTimeWindowState);
-	const changeDayTimeout = useRef<NodeJS.Timeout | null>(null);
-
-	useEffect(() => {
-		return () => {
-			if (changeDayTimeout.current) {
-				clearTimeout(changeDayTimeout.current);
-			}
-		};
-	}, []);
-
-	useEffect(() => {
-		if (currentDate) {
-			setTimeWindow({
-				startDate: currentDate.startOf("day"),
-				endDate: currentDate.endOf("day"),
-				intervalUnit: "day"
-			});
-		}
-	}, [currentDate]);
-
-	function changeDay(direction: "next" | "previous") {
-		changeDayTimeout.current = setTimeout(() => {
-			setCurrentDate((current) => current.add(direction === "next" ? 1 : -1, "day"));
-		}, 25);
-	}
-
-	const activities = useMemo(() => {
-		return Object.values(activitiesData?.byId ?? {}); // TODO: should this not be in a useActivities hook or someting?
-	}, [activitiesData]);
-	const todayActivities = activities.filter((activity) => {
-		return activityFallsOnDay(activity, currentDate);
-	});
-	const allDayActivities = activities.filter((activity) =>
-		isAllDayActivityOnDate(activity, currentDate)
-	);
-	const timestampedActivities = activities.filter(
-		(activity) => !isAllDayActivityOnDate(activity, currentDate)
-	);
-
-	const currentYear = today().year(); // TODO: edge case: make this reactive so it updates on New Year's
-	const title = currentDate.format(
-		`dddd (D MMMM${currentDate.year() !== currentYear ? " YYYY" : ""})`
-	);
-
-	const [speedDialOpen, setSpeedDialOpen] = useState(false);
-
-	// eslint-disable-next-line react-compiler/react-compiler
-	return {
-		habits: getHabitsForTimeWindow(timeWindow),
-		activities: todayActivities,
-		allDayActivities,
-		timestampedActivities,
-		currentDate,
-		setCurrentDate,
-		title,
-		changeDay,
-		speedDialOpen,
-		setSpeedDialOpen
-	} as const;
-}
 
 type SpeedDialActionProps = {
 	$color?: React.ComponentProps<typeof S.SpeedDialButton>["$color"];

--- a/client/src/components/Today/useToday.ts
+++ b/client/src/components/Today/useToday.ts
@@ -1,0 +1,75 @@
+import { activityFallsOnDay, isAllDayActivityOnDate } from "@/lib/activity";
+import { today } from "@/lib/datetime/make-date";
+import useQueryActivities from "@/lib/hooks/query/activities/useQueryActivities";
+import useHabitsData from "@/lib/hooks/useHabitsData";
+import { selectedTimeWindowState } from "@/lib/state/selected-time-window-state";
+import type { Dayjs } from "dayjs";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRecoilState } from "recoil";
+
+/** Functionality hook for the Today component. */
+export default function useToday() {
+	const { data: activitiesData } = useQueryActivities();
+	const { getHabitsForTimeWindow } = useHabitsData();
+	const [currentDate, setCurrentDate] = useState<Dayjs>(() => today());
+	const [timeWindow, setTimeWindow] = useRecoilState(selectedTimeWindowState);
+	const changeDayTimeout = useRef<NodeJS.Timeout | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (changeDayTimeout.current) {
+				clearTimeout(changeDayTimeout.current);
+			}
+		};
+	}, []);
+
+	useEffect(() => {
+		if (currentDate) {
+			setTimeWindow({
+				startDate: currentDate.startOf("day"),
+				endDate: currentDate.endOf("day"),
+				intervalUnit: "day"
+			});
+		}
+	}, [currentDate]);
+
+	function changeDay(direction: "next" | "previous") {
+		changeDayTimeout.current = setTimeout(() => {
+			setCurrentDate((current) => current.add(direction === "next" ? 1 : -1, "day"));
+		}, 25);
+	}
+
+	const activities = useMemo(() => {
+		return Object.values(activitiesData?.byId ?? {}); // TODO: should this not be in a useActivities hook or someting?
+	}, [activitiesData]);
+	const todayActivities = activities.filter((activity) => {
+		return activityFallsOnDay(activity, currentDate);
+	});
+	const allDayActivities = activities.filter((activity) =>
+		isAllDayActivityOnDate(activity, currentDate)
+	);
+	const timestampedActivities = activities.filter(
+		(activity) => !isAllDayActivityOnDate(activity, currentDate)
+	);
+
+	const currentYear = today().year(); // TODO: edge case: make this reactive so it updates on New Year's
+	const title = currentDate.format(
+		`dddd (D MMMM${currentDate.year() !== currentYear ? " YYYY" : ""})`
+	);
+
+	const [speedDialOpen, setSpeedDialOpen] = useState(false);
+
+	// eslint-disable-next-line react-compiler/react-compiler
+	return {
+		habits: getHabitsForTimeWindow(timeWindow),
+		activities: todayActivities,
+		allDayActivities,
+		timestampedActivities,
+		currentDate,
+		setCurrentDate,
+		title,
+		changeDay,
+		speedDialOpen,
+		setSpeedDialOpen
+	} as const;
+}

--- a/client/src/components/utility/Calendar/hooks/create-date.ts
+++ b/client/src/components/utility/Calendar/hooks/create-date.ts
@@ -1,0 +1,14 @@
+import type { Dayjs } from "dayjs";
+
+/** Helper for useCalendar. */
+export function createMonthAndYear(date: Dayjs) {
+	return {
+		month: date.month(),
+		year: date.year()
+	};
+}
+
+/** Helper for useMonthPicker. */
+export function createMonthValue(date: Dayjs) {
+	return new Date(date.year(), date.month(), 1); // note: MonthPicker expects Date, so don't use our dayjs helpers
+}

--- a/client/src/components/utility/Calendar/hooks/useCalendar.ts
+++ b/client/src/components/utility/Calendar/hooks/useCalendar.ts
@@ -1,18 +1,11 @@
 import { buildCalendarRows } from "@/components/utility/Calendar/build-calendar-rows";
 import type { MonthAndYear } from "@/components/utility/Calendar/calendar.types";
+import { createMonthAndYear } from "@/components/utility/Calendar/hooks/create-date";
 import { formatToMonthAndYear } from "@/lib/datetime/format-date";
 import { createDate, createFirstOfTheMonth } from "@/lib/datetime/make-date";
 import type { Maybe } from "@t/data/utility.types";
 import type { Dayjs } from "dayjs";
 import { useCallback, useEffect, useMemo, useState } from "react";
-
-// TODO: put this in a helper file
-function getMonthAndYear(date: Dayjs) {
-	return {
-		month: date.month(),
-		year: date.year()
-	};
-}
 
 type UseCalendarProps = {
 	initialDate: Dayjs;
@@ -35,7 +28,7 @@ export function useCalendar({ initialDate, onChange }: UseCalendarProps) {
 			setSelectedDate(initialDate);
 			// Whenever the outside date changes, update state to reflect that. This
 			// pattern looks a bit messy, but that's what you get with 2-way binding.
-			setMonthAndYear(getMonthAndYear(initialDate));
+			setMonthAndYear(createMonthAndYear(initialDate));
 		}
 	}, [initialDate]);
 
@@ -44,7 +37,7 @@ export function useCalendar({ initialDate, onChange }: UseCalendarProps) {
 	}, [selectedDate]);
 
 	const [monthAndYear, setMonthAndYear] = useState<MonthAndYear>(() =>
-		getMonthAndYear(initialDate)
+		createMonthAndYear(initialDate)
 	);
 
 	const firstDayOfTheMonth = useMemo(

--- a/client/src/components/utility/Calendar/hooks/useCalendar.ts
+++ b/client/src/components/utility/Calendar/hooks/useCalendar.ts
@@ -6,6 +6,14 @@ import type { Maybe } from "@t/data/utility.types";
 import type { Dayjs } from "dayjs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+// TODO: put this in a helper file
+function getMonthAndYear(date: Dayjs) {
+	return {
+		month: date.month(),
+		year: date.year()
+	};
+}
+
 type UseCalendarProps = {
 	initialDate: Dayjs;
 	onChange?: React.Dispatch<React.SetStateAction<Dayjs>>;
@@ -18,18 +26,26 @@ export function useCalendar({ initialDate, onChange }: UseCalendarProps) {
 	useEffect(() => {
 		// This effect is necessary because it's possible to change the date in
 		// other parts of the page, and we want to keep the selected date in sync.
-		// TODO: only update if the day of year changes
-		if (initialDate) setSelectedDate(initialDate);
+		if (initialDate) {
+			// TODO: only update selectedDate if the day of year changes.I guess
+			// this isn't strictly necessary since our day-change methods all set a
+			// _day_, not necessarily a time, but maybe the useCurrentTime hook
+			// messes with that, and we _should_ do the above for perfomrance
+			// reasons.
+			setSelectedDate(initialDate);
+			// Whenever the outside date changes, update state to reflect that. This
+			// pattern looks a bit messy, but that's what you get with 2-way binding.
+			setMonthAndYear(getMonthAndYear(initialDate));
+		}
 	}, [initialDate]);
 
 	useEffect(() => {
 		if (selectedDate) onChange?.(selectedDate);
 	}, [selectedDate]);
 
-	const [monthAndYear, setMonthAndYear] = useState<MonthAndYear>(() => ({
-		month: initialDate.month(),
-		year: initialDate.year()
-	}));
+	const [monthAndYear, setMonthAndYear] = useState<MonthAndYear>(() =>
+		getMonthAndYear(initialDate)
+	);
 
 	const firstDayOfTheMonth = useMemo(
 		() => createFirstOfTheMonth(monthAndYear),

--- a/client/src/components/utility/Calendar/hooks/useMonthPicker.ts
+++ b/client/src/components/utility/Calendar/hooks/useMonthPicker.ts
@@ -1,12 +1,8 @@
 import type { MonthAndYear } from "@/components/utility/Calendar/calendar.types";
+import { createMonthValue } from "@/components/utility/Calendar/hooks/create-date";
 import type { DateValue } from "@mantine/dates";
 import type { Dayjs } from "dayjs";
 import { useEffect, useState } from "react";
-
-// TODO: put this in a helper file
-function createMonthValue(date: Dayjs) {
-	return new Date(date.year(), date.month(), 1); // note: MonthPicker expects Date, so don't use our dayjs helpers
-}
 
 type UseMonthPickerProps = {
 	initialDate: Dayjs;

--- a/client/src/components/utility/Calendar/hooks/useMonthPicker.ts
+++ b/client/src/components/utility/Calendar/hooks/useMonthPicker.ts
@@ -3,6 +3,11 @@ import type { DateValue } from "@mantine/dates";
 import type { Dayjs } from "dayjs";
 import { useEffect, useState } from "react";
 
+// TODO: put this in a helper file
+function createMonthValue(date: Dayjs) {
+	return new Date(date.year(), date.month(), 1); // note: MonthPicker expects Date, so don't use our dayjs helpers
+}
+
 type UseMonthPickerProps = {
 	initialDate: Dayjs;
 	onChange?: React.Dispatch<React.SetStateAction<MonthAndYear>>;
@@ -11,8 +16,15 @@ type UseMonthPickerProps = {
 /** Functionality hook for Calendar.tsx */
 export default function useMonthPicker({ initialDate, onChange }: UseMonthPickerProps) {
 	const [showMonthPicker, setShowMonthPicker] = useState(false);
-	const initialValue = new Date(initialDate.year(), initialDate.month(), 1); // note: MonthPicker expects Date, so don't use our dayjs helpers
-	const [monthValue, setMonthValue] = useState(initialValue);
+
+	const defaultMonthValue = createMonthValue(initialDate);
+	const [monthValue, setMonthValue] = useState(defaultMonthValue);
+
+	useEffect(() => {
+		// Whenever the outside date changes, update state to reflect that. This
+		// pattern looks a bit messy, but that's what you get with 2-way binding.
+		setMonthValue(createMonthValue(initialDate));
+	}, [initialDate]);
 
 	function handleMonthChange(value: DateValue) {
 		if (!value) return;


### PR DESCRIPTION
- update `useMonthPicker` and `useCalendar` states whenever `initialDate` changes.
  I guess maybe `initialDate` then isn't the best named variable anymore)
- extract useToday to its own file for the sake of convention.
  Keeping the hook inside the component .tsx file was an experiment, but I'm too used to having separate hook files now, so this was a good time to move it.