### PR TITLE
`logs.layout` column

### DIFF
--- a/client/src/lib/fetch/logbook-service.ts
+++ b/client/src/lib/fetch/logbook-service.ts
@@ -15,6 +15,7 @@ import type {
 	Log,
 	Logbook,
 	LogbookInput,
+	LogInput,
 	LogTemplate,
 	NewItemInput,
 	NewItemRowInput,
@@ -48,6 +49,11 @@ const logbookService = {
 		post: async (input: NewLogInput) =>
 			api.post<NewLogInput, Log>({
 				url: "/data/logbook/log",
+				body: input
+			}),
+		put: async (input: LogInput) =>
+			api.put<LogInput, Log>({
+				url: `/data/logbook/log/${input.log.log_id}`,
 				body: input
 			})
 	},

--- a/client/src/lib/hooks/query/logbooks/useMutateLog.ts
+++ b/client/src/lib/hooks/query/logbooks/useMutateLog.ts
@@ -1,0 +1,19 @@
+import logbookService from "@/lib/fetch/logbook-service";
+import { queryClient } from "@/lib/query-client";
+import { mk, qk } from "@/lib/query-keys";
+import type { Log, LogInput } from "@t/data/logbook.types";
+import { useMutation } from "@tanstack/react-query";
+
+export default function useMutateLog() {
+	return useMutation<Log, unknown, LogInput>({
+		async mutationFn(logInput) {
+			return logbookService.logs.put(logInput);
+		},
+		mutationKey: mk.logbooks.log.update,
+		onSuccess: () => {
+			// TODO: could invalidate only the updated one, and patch the value into
+			// .all, but this is fine.
+			queryClient.invalidateQueries({ queryKey: qk.logs.all });
+		}
+	});
+}

--- a/client/src/lib/hooks/query/logbooks/useMutateLogbook.ts
+++ b/client/src/lib/hooks/query/logbooks/useMutateLogbook.ts
@@ -1,5 +1,6 @@
 import logbookService from "@/lib/fetch/logbook-service";
-import { mk } from "@/lib/query-keys";
+import { queryClient } from "@/lib/query-client";
+import { mk, qk } from "@/lib/query-keys";
 import type { Logbook, LogbookInput } from "@t/data/logbook.types";
 import { useMutation } from "@tanstack/react-query";
 
@@ -8,6 +9,11 @@ export default function useMutateLogbook() {
 		async mutationFn(logbookInput) {
 			return logbookService.logbooks.put(logbookInput);
 		},
-		mutationKey: mk.logbooks.update
+		mutationKey: mk.logbooks.update,
+		onSuccess: () => {
+			// TODO: could invalidate only the updated one, and patch the value into
+			// .all, but this is fine.
+			queryClient.invalidateQueries({ queryKey: qk.logbooks.all });
+		}
 	});
 }

--- a/client/src/lib/query-keys.ts
+++ b/client/src/lib/query-keys.ts
@@ -96,7 +96,8 @@ const mk = {
 		new: ["new-logbook"],
 		update: ["logbook"],
 		log: {
-			new: ["new-log"]
+			new: ["new-log"],
+			update: ["log"]
 		},
 		template: {
 			new: ["new-log-template"]

--- a/docker/database-setup/18-alter-logs-add-column-layout.sql
+++ b/docker/database-setup/18-alter-logs-add-column-layout.sql
@@ -1,0 +1,2 @@
+ALTER TABLE logs
+ADD column layout jsonb DEFAULT '[]'::jsonb;

--- a/server/src/lib/data/models/logbooks/update-log.ts
+++ b/server/src/lib/data/models/logbooks/update-log.ts
@@ -1,0 +1,21 @@
+import { sqlConnection } from "@/db/init";
+import type { Log } from "@t/data/logbook.types";
+import type { QueryFunction } from "types/sql.types";
+
+/** Set a single Log's values to those in `log`. */
+export const updateLog: QueryFunction<{ log: Log }, Promise<Log>> = async ({
+	sql = sqlConnection,
+	log,
+}) => {
+	// TODO: verify that every value in layout actually belongs to the user
+	// TODO?: remove any values from the layout that no longer exist
+
+	const [updatedLog] = await sql<[Log]>`
+      UPDATE logs
+      SET ${sql(log)}
+      WHERE log_id = ${log.log_id}
+      RETURNING *
+   `;
+
+	return updatedLog;
+};

--- a/server/src/lib/data/models/logbooks/update-log.ts
+++ b/server/src/lib/data/models/logbooks/update-log.ts
@@ -10,11 +10,12 @@ export const updateLog: QueryFunction<{ log: Log }, Promise<Log>> = async ({
 	// TODO: verify that every value in layout actually belongs to the user
 	// TODO?: remove any values from the layout that no longer exist
 
+	const { log_id, ...logWithoutId } = log;
 	const [updatedLog] = await sql<[Log]>`
-      UPDATE logs
-      SET ${sql(log)}
-      WHERE log_id = ${log.log_id}
-      RETURNING *
+     UPDATE logs
+     SET ${sql(logWithoutId)}
+     WHERE log_id = ${log_id}
+     RETURNING *
    `;
 
 	return updatedLog;

--- a/server/src/lib/data/models/logbooks/update-logbook.ts
+++ b/server/src/lib/data/models/logbooks/update-logbook.ts
@@ -1,6 +1,6 @@
 import { sqlConnection } from "@/db/init";
-import { Logbook } from "@t/data/logbook.types";
-import { QueryFunction } from "types/sql.types";
+import type { Logbook } from "@t/data/logbook.types";
+import type { QueryFunction } from "types/sql.types";
 
 /** Set a single logbook's values to those in `logbook`. */
 export const updateLogbook: QueryFunction<

--- a/server/src/lib/data/models/logbooks/update-logbook.ts
+++ b/server/src/lib/data/models/logbooks/update-logbook.ts
@@ -7,9 +7,11 @@ export const updateLogbook: QueryFunction<
 	{ logbook: Logbook },
 	Promise<Logbook>
 > = async ({ sql = sqlConnection, logbook }) => {
+	const { logbook_id, ...logbookWithoutId } = logbook;
+
 	const [updatedLogbook] = await sql<[Logbook]>`
       UPDATE logbooks
-      SET ${sql(logbook)}
+      SET ${sql(logbookWithoutId)}
       WHERE logbook_id = ${logbook.logbook_id}
       RETURNING *
    `;

--- a/server/src/lib/data/request-handlers/put/put-log.ts
+++ b/server/src/lib/data/request-handlers/put/put-log.ts
@@ -1,0 +1,14 @@
+import { updateLog } from "@/lib/data/models/logbooks/update-log";
+import type { Log } from "@t/data/logbook.types";
+import type { RequestHandler } from "express";
+
+/** Request handler for `/data/logbook/:logbook_id`. */
+export const putLog: RequestHandler = async (req, res) => {
+	const { log } = req.body as { log: Log };
+	// TODO: log_id is a param, but we're not directly using it. This is a flaw
+	// in the API design (this issue is also in putLogbook)
+	const log_id = req.params.log_id;
+
+	const updatedLog = await updateLog({ log });
+	res.json(updatedLog);
+};

--- a/server/src/lib/data/request-handlers/put/put-logbook.ts
+++ b/server/src/lib/data/request-handlers/put/put-logbook.ts
@@ -1,5 +1,5 @@
 import { updateLogbook } from "@/lib/data/models/logbooks/update-logbook";
-import { Logbook } from "@t/data/logbook.types";
+import type { Logbook } from "@t/data/logbook.types";
 import type { RequestHandler } from "express";
 
 /** Request handler for `/data/logbook/:logbook_id`. */

--- a/server/src/routers/data.ts
+++ b/server/src/routers/data.ts
@@ -43,6 +43,7 @@ import postNote from "@/lib/data/request-handlers/post/post-note";
 import postTag from "@/lib/data/request-handlers/post/post-tag";
 import putActivity from "@/lib/data/request-handlers/put/put-activity";
 import putHabitEntry from "@/lib/data/request-handlers/put/put-habit-entry";
+import { putLog } from "@/lib/data/request-handlers/put/put-log";
 import { putLogbook } from "@/lib/data/request-handlers/put/put-logbook";
 import putTaskCompletion from "@/lib/data/request-handlers/put/put-task";
 import { Router } from "express";
@@ -121,4 +122,5 @@ dataRouter.get("/logbook/items/template/:item_template_id/items", getItemsByTemp
 dataRouter.get("/logbooks/items", getItems);
 
 /* --- PUT --- */
+dataRouter.put("/logbook/log/:log_id", putLog);
 dataRouter.put("/logbook/:logbook_id", putLogbook);

--- a/shared/types/data/logbook.api.types.ts
+++ b/shared/types/data/logbook.api.types.ts
@@ -3,11 +3,16 @@ import {
 	FieldValue,
 	ItemRow,
 	ItemTemplate,
+	Log,
 	Logbook,
 } from "@t/data/logbook.types";
 
 export type LogbookInput = {
 	logbook: Logbook;
+};
+
+export type LogInput = {
+	log: Log;
 };
 
 export type ItemTemplateAndFieldTemplates = {

--- a/shared/types/data/logbook.types.ts
+++ b/shared/types/data/logbook.types.ts
@@ -108,6 +108,13 @@ export type Item = {
 	created_at: Timestamp;
 };
 
+export type LayoutSection = {
+	item_template_id: ID;
+	item_ids: Nullable<ID[]>;
+};
+
+type Layout = LayoutSection[];
+
 /** A Log represents a filled-in session for a Logbook. */
 export type Log = {
 	log_id: ID;
@@ -126,6 +133,13 @@ export type Log = {
 	end_time: Nullable<Timestamp>;
 
 	created_at: Timestamp;
+
+	/** This describes the layout of the log. In the database, it's implemented
+	 * as a json array, which means that removing an item or item template
+	 * doesn't automatically remove the values from the layout.
+	 * @todo make sure that nonexistent items/item templates do not mess up the
+	 * UI. */
+	layout: Layout;
 };
 
 /** A logbook contains any number of entries that presumably each denote a day,


### PR DESCRIPTION
- add a new `layout` column to the `logs` table. 
- add a matching update query function to the server
- add an endpoint to call this update query
- add a mutation hook and related utilities to call this endpoint from the client

Miscellaneous:
- on successful mutation, invalidate the `logs` query. I noticed that we didn't do this yet for the matching `logbook` PUT hook, so I added invalidation for that hook, too. This is out of scope for this issue, but I'd rather implement it now than add a TODO.
- I noticed that some of the server code for the `putLogbook` function had imports not as types, so I manually fixed that, too. Should probably run an eslint fix on the server to see if there are more cases of this. Don't know how they snuck in.